### PR TITLE
Transfers refacto

### DIFF
--- a/launch/src/config/comparator_type.rs
+++ b/launch/src/config/comparator_type.rs
@@ -36,7 +36,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum ComparatorType {
     Loads,

--- a/launch/src/config/criteria_implem.rs
+++ b/launch/src/config/criteria_implem.rs
@@ -36,7 +36,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum CriteriaImplem {
     Loads,

--- a/launch/src/config/data_implem.rs
+++ b/launch/src/config/data_implem.rs
@@ -36,7 +36,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum DataImplem {
     Periodic,

--- a/launch/src/config/input_data_type.rs
+++ b/launch/src/config/input_data_type.rs
@@ -35,7 +35,8 @@
 // www.navitia.io
 
 use serde::{Deserialize, Serialize};
-#[derive(Debug, Serialize, Deserialize)]
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum InputDataType {
     Gtfs,

--- a/launch/src/config/launch_params.rs
+++ b/launch/src/config/launch_params.rs
@@ -40,7 +40,7 @@ use structopt::StructOpt;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, StructOpt)]
+#[derive(Debug, Serialize, Deserialize, StructOpt, Clone)]
 #[structopt(rename_all = "snake_case")]
 pub struct LaunchParams {
     /// directory containing ntfs/gtfs files to load

--- a/launch/src/datetime.rs
+++ b/launch/src/datetime.rs
@@ -36,7 +36,8 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum DateTimeRepresent {
     Departure,
     Arrival,

--- a/launch/src/stop_areas.rs
+++ b/launch/src/stop_areas.rs
@@ -40,7 +40,7 @@ use crate::config::RequestParams;
 
 pub fn make_query_stop_areas(
     model: &transit_model::Model,
-    departure_datetime: &NaiveDateTime,
+    datetime: &NaiveDateTime,
     from_stop_area: &str,
     to_stop_area: &str,
     request_params: &RequestParams,
@@ -51,7 +51,7 @@ pub fn make_query_stop_areas(
         stops_of_stop_area(model, to_stop_area, PositiveDuration::zero())?;
 
     let request_input = RequestInput {
-        datetime: *departure_datetime,
+        datetime: *datetime,
         departures_stop_point_and_fallback_duration,
         arrivals_stop_point_and_fallback_duration,
         leg_arrival_penalty: request_params.leg_arrival_penalty,

--- a/src/engine/engine_interface.rs
+++ b/src/engine/engine_interface.rs
@@ -134,18 +134,6 @@ pub trait Request: RequestTypes {
         criteria: &Self::Criteria,
     ) -> Self::Criteria;
 
-    /// Performs `transfer` when being at `from_stop` with `criteria`
-    /// and returns the arrival `Stop` along with the `Criteria`
-    /// obtained after performing the transfer.
-    ///
-    /// Panics if `transfer` cannot be performed from `from_stop`.
-    fn transfer(
-        &self,
-        from_stop: &Self::Stop,
-        transfer: &Self::Transfer,
-        criteria: &Self::Criteria,
-    ) -> (Self::Stop, Self::Criteria);
-
     /// Returns the `Stop` at which this departure occurs
     /// along with the initial `Criteria`
     fn depart(&self, departure: &Self::Departure) -> (Self::Stop, Self::Criteria);
@@ -216,17 +204,26 @@ pub trait RequestIters<'a>: RequestTypes {
     /// Iterator for the `Mission`s that can be boarded at a `stop`
     /// along with the `Position` of `stop` on each `Mission`
     type MissionsAtStop: Iterator<Item = (Self::Mission, Self::Position)>;
+
     /// Returns all the `Mission`s that can be boarded at `stop`.
     ///
     /// Should not return twice the same `Mission`.
     fn boardable_missions_at(&'a self, stop: &Self::Stop) -> Self::MissionsAtStop;
 
     /// Iterator for all `Transfer`s that can be taken at a `Stop`
-    type TransfersAtStop: Iterator<Item = Self::Transfer>;
-    /// Returns all `Transfer`s that can be taken at `from_stop`
+    type TransfersAtStop: Iterator<Item = (Self::Stop, Self::Criteria, Self::Transfer)>;
+
+    /// Provides an iterator over all `transfer`s that can be performed
+    /// when being at `from_stop` with `criteria`.
+    /// The iterator returns the arrival `Stop`, the `Criteria`
+    /// obtained after performing the transfer, and the `transfer` id.
     ///
     /// Should not return twice the same `Transfer`.
-    fn transfers_at(&'a self, from_stop: &Self::Stop) -> Self::TransfersAtStop;
+    fn transfers_at(
+        &'a self,
+        from_stop: &Self::Stop,
+        criteria: &Self::Criteria,
+    ) -> Self::TransfersAtStop;
 
     /// Iterator for all `Trip`s belonging to a `Mission`.
     type TripsOfMission: Iterator<Item = Self::Trip>;

--- a/src/engine/multicriteria_raptor.rs
+++ b/src/engine/multicriteria_raptor.rs
@@ -555,8 +555,8 @@ where
                 //     self.arrived_front.add(arrived, arrived_criteria, self.pt);
                 // }
                 // we perform all transfers from the `debarked` path
-                for transfer in pt.transfers_at(stop) {
-                    let (arrival_stop, arrival_criteria) = pt.transfer(stop, &transfer, criteria);
+                for (arrival_stop, arrival_criteria, transfer) in pt.transfers_at(&stop, &criteria)
+                {
                     let arrival_id = pt.stop_id(&arrival_stop);
                     if self.can_be_discarded(&arrival_criteria, pt) {
                         continue;

--- a/src/request/arrive_before/basic_comparator.rs
+++ b/src/request/arrive_before/basic_comparator.rs
@@ -123,15 +123,6 @@ impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Dat
         self.generic.ride(trip, position, criteria)
     }
 
-    fn transfer(
-        &self,
-        from_stop: &Self::Stop,
-        transfer: &Self::Transfer,
-        criteria: &Self::Criteria,
-    ) -> (Self::Stop, Self::Criteria) {
-        self.generic.transfer(from_stop, transfer, criteria)
-    }
-
     fn depart(&self, departure: &Self::Departure) -> (Self::Stop, Self::Criteria) {
         self.generic.depart(departure)
     }
@@ -189,6 +180,8 @@ impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Dat
 impl<'data, 'model, 'outer, Data> RequestIters<'outer> for Request<'data, 'model, Data>
 where
     Data: DataTrait + DataIters<'outer>,
+    Data::Transfer: 'outer,
+    Data::Stop: 'outer,
 {
     type Departures = Departures;
     fn departures(&'outer self) -> Self::Departures {
@@ -205,9 +198,13 @@ where
         self.generic.boardable_missions_at(stop)
     }
 
-    type TransfersAtStop = Data::IncomingTransfersAtStop;
-    fn transfers_at(&'outer self, from_stop: &Self::Stop) -> Self::TransfersAtStop {
-        self.generic.transfers_at(from_stop)
+    type TransfersAtStop = super::TransferAtStop<'outer, Data>;
+    fn transfers_at(
+        &'outer self,
+        from_stop: &Self::Stop,
+        criteria: &Self::Criteria,
+    ) -> Self::TransfersAtStop {
+        self.generic.transfers_at(from_stop, criteria)
     }
 
     type TripsOfMission = Data::TripsOfMission;

--- a/src/request/depart_after/basic_comparator.rs
+++ b/src/request/depart_after/basic_comparator.rs
@@ -123,15 +123,6 @@ impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Dat
         self.generic.ride(trip, position, criteria)
     }
 
-    fn transfer(
-        &self,
-        from_stop: &Self::Stop,
-        transfer: &Self::Transfer,
-        criteria: &Self::Criteria,
-    ) -> (Self::Stop, Self::Criteria) {
-        self.generic.transfer(from_stop, transfer, criteria)
-    }
-
     fn depart(&self, departure: &Self::Departure) -> (Self::Stop, Self::Criteria) {
         self.generic.depart(departure)
     }
@@ -189,6 +180,8 @@ impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Dat
 impl<'data, 'model, 'outer, Data> RequestIters<'outer> for Request<'data, 'model, Data>
 where
     Data: DataTrait + DataIters<'outer>,
+    Data::Transfer: 'outer,
+    Data::Stop: 'outer,
 {
     type Departures = Departures;
     fn departures(&'outer self) -> Self::Departures {
@@ -205,9 +198,13 @@ where
         self.generic.boardable_missions_at(stop)
     }
 
-    type TransfersAtStop = Data::OutgoingTransfersAtStop;
-    fn transfers_at(&'outer self, from_stop: &Self::Stop) -> Self::TransfersAtStop {
-        self.generic.transfers_at(from_stop)
+    type TransfersAtStop = super::TransferAtStop<'outer, Data>;
+    fn transfers_at(
+        &'outer self,
+        from_stop: &Self::Stop,
+        criteria: &Self::Criteria,
+    ) -> Self::TransfersAtStop {
+        self.generic.transfers_at(from_stop, criteria)
     }
 
     type TripsOfMission = Data::TripsOfMission;

--- a/src/request/depart_after/loads_comparator.rs
+++ b/src/request/depart_after/loads_comparator.rs
@@ -127,15 +127,6 @@ impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Dat
         self.generic.ride(trip, position, criteria)
     }
 
-    fn transfer(
-        &self,
-        from_stop: &Self::Stop,
-        transfer: &Self::Transfer,
-        criteria: &Self::Criteria,
-    ) -> (Self::Stop, Self::Criteria) {
-        self.generic.transfer(from_stop, transfer, criteria)
-    }
-
     fn depart(&self, departure: &Self::Departure) -> (Self::Stop, Self::Criteria) {
         self.generic.depart(departure)
     }
@@ -193,6 +184,8 @@ impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Dat
 impl<'data, 'model, 'outer, Data> RequestIters<'outer> for Request<'data, 'model, Data>
 where
     Data: DataTrait + DataIters<'outer>,
+    Data::Transfer: 'outer,
+    Data::Stop: 'outer,
 {
     type Departures = Departures;
     fn departures(&'outer self) -> Self::Departures {
@@ -209,9 +202,13 @@ where
         self.generic.boardable_missions_at(stop)
     }
 
-    type TransfersAtStop = Data::OutgoingTransfersAtStop;
-    fn transfers_at(&'outer self, from_stop: &Self::Stop) -> Self::TransfersAtStop {
-        self.generic.transfers_at(from_stop)
+    type TransfersAtStop = super::TransferAtStop<'outer, Data>;
+    fn transfers_at(
+        &'outer self,
+        from_stop: &Self::Stop,
+        criteria: &Self::Criteria,
+    ) -> Self::TransfersAtStop {
+        self.generic.transfers_at(from_stop, criteria)
     }
 
     type TripsOfMission = Data::TripsOfMission;
@@ -220,8 +217,13 @@ where
     }
 }
 
-impl<'data, 'model, Data> RequestWithIters for Request<'data, 'model, Data> where Data: DataWithIters
-{}
+impl<'data, 'model, Data> RequestWithIters for Request<'data, 'model, Data>
+where
+    Data: DataWithIters,
+    Data::Transfer: 'static,
+    Data::Stop: 'static,
+{
+}
 
 use crate::engine::engine_interface::Journey as PTJourney;
 use crate::response;

--- a/stop_areas/src/lib.rs
+++ b/stop_areas/src/lib.rs
@@ -81,7 +81,7 @@ pub struct ConfigFile {
     #[structopt(parse(from_os_str))]
     file: std::path::PathBuf,
 }
-#[derive(Serialize, Deserialize, StructOpt)]
+#[derive(Serialize, Deserialize, StructOpt, Clone)]
 #[structopt(rename_all = "snake_case")]
 pub struct Config {
     #[serde(flatten)]
@@ -92,11 +92,13 @@ pub struct Config {
     #[structopt(flatten)]
     pub request_params: config::RequestParams,
 
-    /// Departure datetime of the query, formatted like 20190628T163215
+    /// Datetime of the query , formatted like 20190628T163215
+    /// This datetime will be interpreted as a departure time or arrival time,
+    /// depending on the value of the datetime_represent parameter.
     /// If none is given, all queries will be made at 08:00:00 on the first
     /// valid day of the dataset
     #[structopt(long)]
-    pub departure_datetime: Option<String>,
+    pub datetime: Option<String>,
 
     /// "departure_datetime" can represent
     /// a DepartureAfter datetime
@@ -187,7 +189,7 @@ where
 {
     let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());
 
-    let departure_datetime = match &config.departure_datetime {
+    let datetime = match &config.datetime {
         Some(string_datetime) => launch::datetime::parse_datetime(&string_datetime)?,
         None => {
             let naive_date = data.calendar().first_date();
@@ -204,7 +206,7 @@ where
 
     let request_input = launch::stop_areas::make_query_stop_areas(
         model,
-        &departure_datetime,
+        &datetime,
         start_stop_area_uri,
         end_stop_area_uri,
         &config.request_params,


### PR DESCRIPTION
# TransitData
- the type Transfer is now just an index
- transit_data stores transfer data three times : 
  - once in a global vec transit_data.transfers_data. The Transfer.idx is just an index into this vec
  - once in from_stop.outgoing_transfers
  - once in to_stop.incoming_transfers
- transit_data.transfers_data stores all info about the transfer, in particular the transit_model_idx
- for a transfer, we now stores the total duration of the transfer, and the walking duration (where total duration should be walking_duration + a margin)
- on the other hand stop.outgoing/incoming_transfers just stores what is useful for the engine : the other stop, the durations, and the Transfer id

# Request trait
-  merge the two functions transfers_at(stop) -> Iter<Transfer> and transfer(transfer, criteria) -> (Stop, Criteria)
   into transfers_at(stop, criteria) -> Iter< (Stop, Criteria, Transfer)