### PR TITLE
add timeout when consuming rabbitmq

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,7 +16,7 @@ protobuf = "2"
 
 # Zmq lib with async interface
 tmq = "0.3"
-tokio = { version = "1", features = ["sync", "macros", "rt"] }
+tokio = { version = "1.12.0", features = ["sync", "macros", "rt"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 
 # RabbitMq lib


### PR DESCRIPTION
This PR aims at 2 major problems that may happen, when consuming real-time messages from rabbtimq:

1.  Worker keeps consuming messages from rabbitmq and appending them into the temporary buffer despite the elapsed `timeout`. Because messages could arrive by the time `timeout` elapses and the worker will just continue appending messages, and the buffer won't be sent.
2. If there're a large number of messages in the queue to be consumed (ex: 1M), instead of appending all messages in the buffer, we prefer handling them by batch. (5000 message)