### PR TITLE
add support for sonarcloud from clippy

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -28,7 +28,11 @@ jobs:
           components: clippy
     - name: Run cargo clippy
       run: cargo clippy --workspace --all-features --message-format=json -- --warn clippy::pedantic > clippy.json
-    - name: Run sonarqube
+    - name: Install 'cargo-sonar'
+      run: cargo install cargo-sonar
+    - name: Convert into Sonar compatible format
+      run: cargo-sonar --clippy
+    - name: Run sonar-scanner
       uses: SonarSource/sonarcloud-github-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -39,6 +43,6 @@ jobs:
           -Dsonar.projectName=loki
           -Dsonar.sources=.
           -Dsonar.sourceEncoding=UTF-8
-          -Dsonar.rust.clippy.reportPaths=clippy.json
+          -Dsonar.rust.clippy.reportPaths=sonar.json
           -Dsonar.organization=canaltp
           -Dsonar.verbose=true


### PR DESCRIPTION
Some experimentation to forward `clippy`'s output to Sonarcloud. I'm opening this as a draft for now since it'll be testing that it works through Github Actions.