### PR TITLE
Simplify dockers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 target
 mc_navitia*
 .github
-data
+data*

--- a/.github/workflows/dockers.yml
+++ b/.github/workflows/dockers.yml
@@ -29,9 +29,9 @@ jobs:
     - name: install test depedencies
       run: sudo apt install -y httpie jq
 
-    - name: Test corse basic
+    - name: Test corse loki
       run: |
-        result=$( http GET 'http://127.0.0.1:9191/v1/coverage/corse-loki/journeys?from=8.73421%3B41.91907&to=8.76055%3B41.92878&datetime=20200505T091505&_override_scenario=distributed&' | jq .journeys[0].duration)
+        result=$( http GET 'http://127.0.0.1:9191/v1/coverage/corse/journeys?from=8.73421%3B41.91907&to=8.76055%3B41.92878&datetime=20200505T091505&_override_scenario=distributed&' | jq .journeys[0].duration)
         test $result != null
     - name: Test corse kraken
       run: |
@@ -40,7 +40,7 @@ jobs:
 
     - name: Test transilien basic
       run: |
-        result=$( http GET 'http://127.0.0.1:9191/v1/coverage/transilien-loki/journeys?from=stop_area%3ADUA8775810&to=stop_area%3ADUA8739357&datetime=20210322T142346&_override_scenario=distributed&' | jq .journeys[0].duration)
+        result=$( http GET 'http://127.0.0.1:9191/v1/coverage/transilien/journeys?from=stop_area%3ADUA8775810&to=stop_area%3ADUA8739357&datetime=20210322T142346&_override_scenario=distributed&_use_pt_socket=True&' | jq .journeys[0].duration)
         test $result != null
     - name: Test transilien kraken
       run: |
@@ -49,7 +49,7 @@ jobs:
 
     - name: Test idfm basic
       run: |
-        result=$( http GET 'http://127.0.0.1:9191/v1/coverage/idfm-loki/journeys?from=stop_area%3Astop_area%3A8775810&to=stop_area%3Astop_area%3A59033&datetime=20200505T080000&_override_scenario=distributed&' | jq .journeys[0].duration)
+        result=$( http GET 'http://127.0.0.1:9191/v1/coverage/idfm/journeys?from=stop_area%3Astop_area%3A8775810&to=stop_area%3Astop_area%3A59033&datetime=20200505T080000&_override_scenario=distributed&_use_pt_socket=True&' | jq .journeys[0].duration)
         test $result != null
     - name: Test idfm kraken
       run: |

--- a/docker/bina.sh
+++ b/docker/bina.sh
@@ -195,30 +195,15 @@ for folder in $(ls -d */); do
 
 
     krakenPort="30000"
-    lokiBasicPort="30001"
-    lokiLoadsPort="30002"
+    lokiPort="30001"
 
     # Jormun config files
-
-    # old fashion Kraken
-    jq -n --arg instance "${coverage}" --arg krakenSocket "tcp://kraken-${coverage}:${krakenPort}" '{
+    jq -n --arg instance "${coverage}" --arg krakenSocket "tcp://kraken-${coverage}:${krakenPort}" --arg lokiSocket "tcp://loki-${coverage}:${lokiPort}" '{
     key: $instance,
-    zmq_socket: $krakenSocket
+    zmq_socket: $krakenSocket,
+    pt_zmq_socket : $lokiSocket
 }'  > ${output}/jormun_conf/${coverage}.json
 
-    # "loki" with basic comparator
-    jq -n --arg instance "${coverage}-loki" --arg krakenSocket "tcp://kraken-${coverage}:${krakenPort}" --arg lokiSocket "tcp://loki-${coverage}:${lokiBasicPort}" '{
-    key: $instance,
-    zmq_socket: $krakenSocket,
-    pt_zmq_socket : $lokiSocket
-}'  > ${output}/jormun_conf/${coverage}-loki.json
-
-    # "loki" with loads comparator
-    jq -n --arg instance "${coverage}-loki-loads" --arg krakenSocket "tcp://kraken-${coverage}:${krakenPort}" --arg lokiSocket "tcp://loki-${coverage}:${lokiLoadsPort}" '{
-    key: $instance,
-    zmq_socket: $krakenSocket,
-    pt_zmq_socket : $lokiSocket
-}'  > ${output}/jormun_conf/${coverage}-loki-loads.json
 
 
 
@@ -231,18 +216,14 @@ zmq_socket = tcp://*:${krakenPort}
 " > ${output}/${coverage}/kraken.ini
 
     # Loki config files
-    jq -n --arg basicSocket "tcp://*:$lokiBasicPort" \
-          --arg loadsSocket "tcp://*:$lokiLoadsPort" \
+    jq -n --arg lokiSocket "tcp://*:$lokiPort" \
           --arg inputType "$inputType" \
           --arg inputPath "/data/$inputType/" \
           '{
     input_data_path: $inputPath,
     input_data_type: $inputType,
     loads_data_path: "/data/stoptimes_loads.csv",
-    basic_requests_socket: $basicSocket,
-    loads_requests_socket: $loadsSocket,
-    data_implem: "periodic_split_vj",
-    criteria_implem: "loads"
+    requests_socket: $lokiSocket,
 }' > ${output}/${coverage}/loki_config.json
 
 

--- a/docker/loki_dockerfile
+++ b/docker/loki_dockerfile
@@ -1,6 +1,12 @@
 FROM rust:buster as builder
 WORKDIR /usr/src/myapp
-COPY . .
+COPY ./Cargo.toml ./Cargo.toml
+COPY ./src/ ./src/
+COPY ./launch/ ./launch/
+COPY ./server/ ./server/
+COPY ./stop_areas/ ./stop_areas/
+COPY ./random/ ./random/
+
 
 RUN apt-get update && apt-get install -y libzmq3-dev
 RUN cargo install --path server

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -104,14 +104,8 @@ pub struct Config {
     launch_params: config::LaunchParams,
 
     /// zmq socket to listen for protobuf requests
-    /// that will be handled with "basic" comparator
     #[structopt(long)]
-    basic_requests_socket: String,
-
-    /// zmq socket to listen for protobuf requests
-    /// that will be handled with "loads" comparator
-    #[structopt(long)]
-    loads_requests_socket: Option<String>,
+    requests_socket: String,
 
     #[serde(flatten)]
     #[structopt(flatten)]

--- a/server/src/master_worker.rs
+++ b/server/src/master_worker.rs
@@ -123,7 +123,7 @@ impl MasterWorker {
             base_data_and_model.clone(),
             real_time_data_and_model.clone(),
             config.nb_workers,
-            &config.basic_requests_socket,
+            &config.requests_socket,
             &config.request_default_params,
         )?;
         let _load_balancer_thread_handle = load_balancer.run_in_a_thread()?;

--- a/server/src/zmq_worker.rs
+++ b/server/src/zmq_worker.rs
@@ -251,7 +251,7 @@ fn handle_incoming_request(
             };
             let send_result = requests_sender.send(request_message);
             if let Err(err) = send_result {
-                error!("Error while forwarding request to master_worker : {}", err);
+                error!("Error while forwarding request to load balancer : {}", err);
                 // TODO : what to do here ?
                 // if an error occurs while sending
                 // it means that the receiver of the channel is closed


### PR DESCRIPTION
Jormugandr [now](https://github.com/CanalTP/navitia/pull/3608) have the _use_pt_socket parameters, which can be used to call loki instead of kraken on a coverage.
Consequently, we do not need to create *-loki coverages, but we can keep only one coverage per dataset and add _use_pt_socket=True in the requests to call the loki backend instead of kraken.