### PR TITLE
Realtime and Base scheduled merged in a single transit_data

### DIFF
--- a/launch/src/config/request_params.rs
+++ b/launch/src/config/request_params.rs
@@ -68,13 +68,12 @@ pub struct RequestParams {
     #[serde(default = "default_too_late_threshold")]
     pub too_late_threshold: PositiveDuration,
 
-
     /// Which version of the data to use for computing journeys ?
     /// base : the initial scheduled provided in the ntfs, disregarding real time updates
-    /// real_time : includes the real time updates 
+    /// real_time : includes the real time updates
     #[structopt(long, default_value = DEFAULT_REAL_TIME_LEVEL)]
     #[serde(default = "default_real_time_level")]
-    pub real_time_level : RealTimeLevel,
+    pub real_time_level: RealTimeLevel,
 }
 
 pub const DEFAULT_LEG_ARRIVAL_PENALTY: &str = "00:02:00";
@@ -82,7 +81,7 @@ pub const DEFAULT_LEG_WALKING_PENALTY: &str = "00:02:00";
 pub const DEFAULT_MAX_NB_LEGS: &str = "10";
 pub const DEFAULT_MAX_JOURNEY_DURATION: &str = "24:00:00";
 pub const DEFAULT_TOO_LATE_THRESHOLD: &str = "02:00:00";
-pub const DEFAULT_REAL_TIME_LEVEL: &str ="base";
+pub const DEFAULT_REAL_TIME_LEVEL: &str = "base";
 
 pub fn default_leg_arrival_penalty() -> PositiveDuration {
     PositiveDuration::from_str(DEFAULT_LEG_ARRIVAL_PENALTY).unwrap()
@@ -116,7 +115,7 @@ impl Default for RequestParams {
             max_nb_of_legs: default_max_nb_of_legs(),
             max_journey_duration: default_max_journey_duration(),
             too_late_threshold: default_too_late_threshold(),
-            real_time_level : default_real_time_level()
+            real_time_level: default_real_time_level(),
         }
     }
 }

--- a/launch/src/config/request_params.rs
+++ b/launch/src/config/request_params.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use structopt::StructOpt;
 
-use loki::PositiveDuration;
+use loki::{PositiveDuration, RealTimeLevel};
 #[derive(Debug, Clone, Serialize, Deserialize, StructOpt)]
 #[structopt(rename_all = "snake_case")]
 pub struct RequestParams {
@@ -67,6 +67,14 @@ pub struct RequestParams {
     #[structopt(long, default_value = DEFAULT_TOO_LATE_THRESHOLD)]
     #[serde(default = "default_too_late_threshold")]
     pub too_late_threshold: PositiveDuration,
+
+
+    /// Which version of the data to use for computing journeys ?
+    /// base : the initial scheduled provided in the ntfs, disregarding real time updates
+    /// real_time : includes the real time updates 
+    #[structopt(long, default_value = DEFAULT_REAL_TIME_LEVEL)]
+    #[serde(default = "default_real_time_level")]
+    pub real_time_level : RealTimeLevel,
 }
 
 pub const DEFAULT_LEG_ARRIVAL_PENALTY: &str = "00:02:00";
@@ -74,6 +82,7 @@ pub const DEFAULT_LEG_WALKING_PENALTY: &str = "00:02:00";
 pub const DEFAULT_MAX_NB_LEGS: &str = "10";
 pub const DEFAULT_MAX_JOURNEY_DURATION: &str = "24:00:00";
 pub const DEFAULT_TOO_LATE_THRESHOLD: &str = "02:00:00";
+pub const DEFAULT_REAL_TIME_LEVEL: &str ="base";
 
 pub fn default_leg_arrival_penalty() -> PositiveDuration {
     PositiveDuration::from_str(DEFAULT_LEG_ARRIVAL_PENALTY).unwrap()
@@ -95,6 +104,10 @@ pub fn default_too_late_threshold() -> PositiveDuration {
     PositiveDuration::from_str(DEFAULT_TOO_LATE_THRESHOLD).unwrap()
 }
 
+pub fn default_real_time_level() -> RealTimeLevel {
+    RealTimeLevel::Base
+}
+
 impl Default for RequestParams {
     fn default() -> Self {
         Self {
@@ -103,6 +116,7 @@ impl Default for RequestParams {
             max_nb_of_legs: default_max_nb_of_legs(),
             max_journey_duration: default_max_journey_duration(),
             too_late_threshold: default_too_late_threshold(),
+            real_time_level : default_real_time_level()
         }
     }
 }

--- a/launch/src/read.rs
+++ b/launch/src/read.rs
@@ -51,7 +51,7 @@ pub fn read<Timetables>(
     launch_params: &config::LaunchParams,
 ) -> Result<(TransitData<Timetables>, BaseModel), transit_model::Error>
 where
-    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> ,
+    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a>,
 {
     let base_model = read_model(launch_params)?;
 
@@ -127,7 +127,7 @@ pub fn build_transit_data<Timetables>(
     default_transfer_duration: &PositiveDuration,
 ) -> TransitData<Timetables>
 where
-    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> ,
+    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a>,
 {
     info!(
         "Number of vehicle journeys : {}",

--- a/launch/src/read.rs
+++ b/launch/src/read.rs
@@ -40,7 +40,6 @@ use crate::{
     loki::{timetables::TimetablesIter, TransitData},
 };
 use loki::{
-    chrono::NaiveDate,
     models::base_model::BaseModel,
     timetables::Timetables as TimetablesTrait,
     tracing::{info, warn},
@@ -62,7 +61,6 @@ where
         &base_model,
         &loads_data,
         &launch_params.default_transfer_duration,
-        None,
     );
 
     Ok((data, base_model))
@@ -127,7 +125,6 @@ pub fn build_transit_data<Timetables>(
     base_model: &BaseModel,
     loads_data: &LoadsData,
     default_transfer_duration: &PositiveDuration,
-    restrict_calendar: Option<(NaiveDate, NaiveDate)>,
 ) -> TransitData<Timetables>
 where
     Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> + Debug,
@@ -139,12 +136,7 @@ where
     info!("Number of routes : {}", base_model.routes.len());
 
     let data_timer = SystemTime::now();
-    let data = TransitData::new(
-        base_model,
-        loads_data,
-        *default_transfer_duration,
-        restrict_calendar,
-    );
+    let data = TransitData::new(base_model, loads_data, *default_transfer_duration);
     let data_build_duration = data_timer.elapsed().unwrap().as_millis();
     info!("Data constructed in {} ms", data_build_duration);
     info!("Number of missions {} ", data.nb_of_missions());

--- a/launch/src/read.rs
+++ b/launch/src/read.rs
@@ -45,13 +45,13 @@ use loki::{
     tracing::{info, warn},
     transit_model, DataIO, DataTrait, LoadsData, PositiveDuration,
 };
-use std::{collections::BTreeMap, fmt::Debug, time::SystemTime};
+use std::{collections::BTreeMap, time::SystemTime};
 
 pub fn read<Timetables>(
     launch_params: &config::LaunchParams,
 ) -> Result<(TransitData<Timetables>, BaseModel), transit_model::Error>
 where
-    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> + Debug,
+    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> ,
 {
     let base_model = read_model(launch_params)?;
 
@@ -127,7 +127,7 @@ pub fn build_transit_data<Timetables>(
     default_transfer_duration: &PositiveDuration,
 ) -> TransitData<Timetables>
 where
-    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> + Debug,
+    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> ,
 {
     info!(
         "Number of vehicle journeys : {}",

--- a/launch/src/solver.rs
+++ b/launch/src/solver.rs
@@ -93,7 +93,7 @@ impl Solver {
             Position = generic_request::Position,
             Trip = generic_request::Trip,
         >,
-        Timetables: for<'a> TimetablesIter<'a> + Debug,
+        Timetables: for<'a> TimetablesIter<'a>,
         Timetables::Mission: 'static,
         Timetables::Position: 'static,
     {

--- a/launch/src/stop_areas.rs
+++ b/launch/src/stop_areas.rs
@@ -34,7 +34,7 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use loki::{models::base_model::BaseModel, NaiveDateTime, PositiveDuration, RequestInput};
+use loki::{NaiveDateTime, PositiveDuration, RealTimeLevel, RequestInput, models::{ base_model::BaseModel}};
 
 use crate::config::RequestParams;
 
@@ -59,6 +59,7 @@ pub fn make_query_stop_areas(
         max_nb_of_legs: request_params.max_nb_of_legs,
         max_journey_duration: request_params.max_journey_duration,
         too_late_threshold: request_params.too_late_threshold,
+        real_time_level : RealTimeLevel::Base,
     };
 
     Ok(request_input)

--- a/launch/src/stop_areas.rs
+++ b/launch/src/stop_areas.rs
@@ -34,7 +34,9 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use loki::{NaiveDateTime, PositiveDuration, RealTimeLevel, RequestInput, models::{ base_model::BaseModel}};
+use loki::{
+    models::base_model::BaseModel, NaiveDateTime, PositiveDuration, RealTimeLevel, RequestInput,
+};
 
 use crate::config::RequestParams;
 
@@ -59,7 +61,7 @@ pub fn make_query_stop_areas(
         max_nb_of_legs: request_params.max_nb_of_legs,
         max_journey_duration: request_params.max_journey_duration,
         too_late_threshold: request_params.too_late_threshold,
-        real_time_level : RealTimeLevel::Base,
+        real_time_level: RealTimeLevel::Base,
     };
 
     Ok(request_input)

--- a/launch/tests/update_data_test.rs
+++ b/launch/tests/update_data_test.rs
@@ -106,7 +106,6 @@ where
         &base_model,
         &loki::LoadsData::empty(),
         &config.default_transfer_duration,
-        None,
     );
 
     let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());
@@ -242,7 +241,6 @@ where
         &base_model,
         &loki::LoadsData::empty(),
         &config.default_transfer_duration,
-        None,
     );
 
     let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());
@@ -399,7 +397,6 @@ where
         &base_model,
         &loki::LoadsData::empty(),
         &config.default_transfer_duration,
-        None,
     );
 
     let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());

--- a/launch/tests/update_data_test.rs
+++ b/launch/tests/update_data_test.rs
@@ -36,7 +36,6 @@
 
 mod utils;
 
-
 use failure::Error;
 use launch::{config::DataImplem, solver::Solver};
 
@@ -45,7 +44,6 @@ use loki::{
     request::generic_request,
     timetables::{Timetables, TimetablesIter},
     DailyData, DataTrait, DataUpdate, PeriodicData, PeriodicSplitVjData, RealTimeLevel,
-
 };
 use utils::{
     disruption_builder::{modify, StopTimesBuilder},
@@ -74,7 +72,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    T: for<'a> TimetablesIter<'a> ,
+    T: for<'a> TimetablesIter<'a>,
     T::Mission: 'static,
     T::Position: 'static,
 {
@@ -205,7 +203,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    T: for<'a> TimetablesIter<'a> ,
+    T: for<'a> TimetablesIter<'a>,
     T::Mission: 'static,
     T::Position: 'static,
 {
@@ -364,7 +362,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    T: for<'a> TimetablesIter<'a> ,
+    T: for<'a> TimetablesIter<'a>,
     T::Mission: 'static,
     T::Position: 'static,
 {
@@ -499,7 +497,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    T: for<'a> TimetablesIter<'a> ,
+    T: for<'a> TimetablesIter<'a>,
     T::Mission: 'static,
     T::Position: 'static,
 {

--- a/launch/tests/update_data_test.rs
+++ b/launch/tests/update_data_test.rs
@@ -36,7 +36,6 @@
 
 mod utils;
 
-use std::fmt::Debug;
 
 use failure::Error;
 use launch::{config::DataImplem, solver::Solver};
@@ -46,10 +45,10 @@ use loki::{
     request::generic_request,
     timetables::{Timetables, TimetablesIter},
     DailyData, DataTrait, DataUpdate, PeriodicData, PeriodicSplitVjData, RealTimeLevel,
-    RequestInput,
+
 };
 use utils::{
-    disruption_builder::{add, delete, modify, StopTimesBuilder},
+    disruption_builder::{modify, StopTimesBuilder},
     model_builder::{AsDate, ModelBuilder},
     Config,
 };
@@ -75,7 +74,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    T: for<'a> TimetablesIter<'a> + Debug,
+    T: for<'a> TimetablesIter<'a> ,
     T::Mission: 'static,
     T::Position: 'static,
 {
@@ -140,7 +139,7 @@ where
     let vehicle_journey_idx = base_model.vehicle_journeys.get_idx("first").unwrap();
     let vj_idx = VehicleJourneyIdx::Base(vehicle_journey_idx);
 
-    data.remove_vehicle(&vj_idx, &"2020-01-01".as_date(), RealTimeLevel::Base)
+    data.remove_real_time_vehicle(&vj_idx, &"2020-01-01".as_date())
         .unwrap();
 
     {
@@ -205,7 +204,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    T: for<'a> TimetablesIter<'a> + Debug,
+    T: for<'a> TimetablesIter<'a> ,
     T::Mission: 'static,
     T::Position: 'static,
 {
@@ -269,7 +268,7 @@ where
     {
         let vehicle_journey_idx = base_model.vehicle_journeys.get_idx("first").unwrap();
         let vj_idx = VehicleJourneyIdx::Base(vehicle_journey_idx);
-        data.remove_vehicle(&vj_idx, &"2020-01-01".as_date(), RealTimeLevel::Base)
+        data.remove_real_time_vehicle(&vj_idx, &"2020-01-01".as_date())
             .unwrap();
     }
 
@@ -295,7 +294,7 @@ where
     {
         let vehicle_journey_idx = base_model.vehicle_journeys.get_idx("second").unwrap();
         let vj_idx = VehicleJourneyIdx::Base(vehicle_journey_idx);
-        data.remove_vehicle(&vj_idx, &"2020-01-01".as_date(), RealTimeLevel::Base)
+        data.remove_real_time_vehicle(&vj_idx, &"2020-01-01".as_date())
             .unwrap();
     }
 
@@ -321,7 +320,7 @@ where
     {
         let vehicle_journey_idx = base_model.vehicle_journeys.get_idx("third").unwrap();
         let vj_idx = VehicleJourneyIdx::Base(vehicle_journey_idx);
-        data.remove_vehicle(&vj_idx, &"2020-01-01".as_date(), RealTimeLevel::Base)
+        data.remove_real_time_vehicle(&vj_idx, &"2020-01-01".as_date())
             .unwrap();
     }
 
@@ -361,7 +360,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    T: for<'a> TimetablesIter<'a> + Debug,
+    T: for<'a> TimetablesIter<'a> ,
     T::Mission: 'static,
     T::Position: 'static,
 {
@@ -425,7 +424,7 @@ where
     {
         let vehicle_journey_idx = base_model.vehicle_journeys.get_idx("first").unwrap();
         let vj_idx = VehicleJourneyIdx::Base(vehicle_journey_idx);
-        data.remove_vehicle(&vj_idx, &"2020-01-01".as_date(), RealTimeLevel::Base)
+        data.remove_real_time_vehicle(&vj_idx, &"2020-01-01".as_date())
             .unwrap();
     }
 
@@ -451,7 +450,7 @@ where
     {
         let vehicle_journey_idx = base_model.vehicle_journeys.get_idx("third").unwrap();
         let vj_idx = VehicleJourneyIdx::Base(vehicle_journey_idx);
-        data.remove_vehicle(&vj_idx, &"2020-01-01".as_date(), RealTimeLevel::Base)
+        data.remove_real_time_vehicle(&vj_idx, &"2020-01-01".as_date())
             .unwrap();
     }
 
@@ -496,7 +495,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    T: for<'a> TimetablesIter<'a> + Debug,
+    T: for<'a> TimetablesIter<'a> ,
     T::Mission: 'static,
     T::Position: 'static,
 {

--- a/launch/tests/update_data_test.rs
+++ b/launch/tests/update_data_test.rs
@@ -45,7 +45,7 @@ use loki::{
     models::{base_model::BaseModel, real_time_model::RealTimeModel, ModelRefs, VehicleJourneyIdx},
     request::generic_request,
     timetables::{Timetables, TimetablesIter},
-    DailyData, DataTrait, DataUpdate, PeriodicData, PeriodicSplitVjData,
+    DailyData, DataTrait, DataUpdate, PeriodicData, PeriodicSplitVjData, RealTimeLevel,
 };
 use utils::{
     model_builder::{AsDate, ModelBuilder},
@@ -139,7 +139,7 @@ where
     let vehicle_journey_idx = base_model.vehicle_journeys.get_idx("first").unwrap();
     let vj_idx = VehicleJourneyIdx::Base(vehicle_journey_idx);
 
-    data.remove_vehicle(&vj_idx, &"2020-01-01".as_date())
+    data.remove_vehicle(&vj_idx, &"2020-01-01".as_date(), RealTimeLevel::Base)
         .unwrap();
 
     {
@@ -269,7 +269,7 @@ where
     {
         let vehicle_journey_idx = base_model.vehicle_journeys.get_idx("first").unwrap();
         let vj_idx = VehicleJourneyIdx::Base(vehicle_journey_idx);
-        data.remove_vehicle(&vj_idx, &"2020-01-01".as_date())
+        data.remove_vehicle(&vj_idx, &"2020-01-01".as_date(), RealTimeLevel::Base)
             .unwrap();
     }
 
@@ -295,7 +295,7 @@ where
     {
         let vehicle_journey_idx = base_model.vehicle_journeys.get_idx("second").unwrap();
         let vj_idx = VehicleJourneyIdx::Base(vehicle_journey_idx);
-        data.remove_vehicle(&vj_idx, &"2020-01-01".as_date())
+        data.remove_vehicle(&vj_idx, &"2020-01-01".as_date(), RealTimeLevel::Base)
             .unwrap();
     }
 
@@ -321,7 +321,7 @@ where
     {
         let vehicle_journey_idx = base_model.vehicle_journeys.get_idx("third").unwrap();
         let vj_idx = VehicleJourneyIdx::Base(vehicle_journey_idx);
-        data.remove_vehicle(&vj_idx, &"2020-01-01".as_date())
+        data.remove_vehicle(&vj_idx, &"2020-01-01".as_date(), RealTimeLevel::Base)
             .unwrap();
     }
 
@@ -426,7 +426,7 @@ where
     {
         let vehicle_journey_idx = base_model.vehicle_journeys.get_idx("first").unwrap();
         let vj_idx = VehicleJourneyIdx::Base(vehicle_journey_idx);
-        data.remove_vehicle(&vj_idx, &"2020-01-01".as_date())
+        data.remove_vehicle(&vj_idx, &"2020-01-01".as_date(), RealTimeLevel::Base)
             .unwrap();
     }
 
@@ -452,7 +452,7 @@ where
     {
         let vehicle_journey_idx = base_model.vehicle_journeys.get_idx("third").unwrap();
         let vj_idx = VehicleJourneyIdx::Base(vehicle_journey_idx);
-        data.remove_vehicle(&vj_idx, &"2020-01-01".as_date())
+        data.remove_vehicle(&vj_idx, &"2020-01-01".as_date(), RealTimeLevel::Base)
             .unwrap();
     }
 

--- a/launch/tests/update_data_test.rs
+++ b/launch/tests/update_data_test.rs
@@ -578,6 +578,8 @@ where
     }
 
     {
+        let mut request_input = request_input.clone();
+        request_input.real_time_level = RealTimeLevel::Base;
         let model_refs = ModelRefs::new(&base_model, &real_time_model);
 
         let responses = solver.solve_request(

--- a/launch/tests/update_data_test.rs
+++ b/launch/tests/update_data_test.rs
@@ -46,8 +46,10 @@ use loki::{
     request::generic_request,
     timetables::{Timetables, TimetablesIter},
     DailyData, DataTrait, DataUpdate, PeriodicData, PeriodicSplitVjData, RealTimeLevel,
+    RequestInput,
 };
 use utils::{
+    disruption_builder::{add, delete, modify, StopTimesBuilder},
     model_builder::{AsDate, ModelBuilder},
     Config,
 };
@@ -469,6 +471,132 @@ where
         assert_eq!(
             model_refs.vehicle_journey_name(&journey.first_vehicle.vehicle_journey),
             "second"
+        );
+    }
+
+    Ok(())
+}
+
+#[rstest]
+#[case(DataImplem::Periodic)]
+#[case(DataImplem::Daily)]
+#[case(DataImplem::PeriodicSplitVj)]
+fn modify_vj(#[case] data_implem: DataImplem) -> Result<(), Error> {
+    match data_implem {
+        DataImplem::Periodic => modify_vj_inner::<PeriodicData>(),
+        DataImplem::PeriodicSplitVj => modify_vj_inner::<PeriodicSplitVjData>(),
+        DataImplem::Daily => modify_vj_inner::<DailyData>(),
+    }
+}
+
+fn modify_vj_inner<T>() -> Result<(), Error>
+where
+    T: Timetables<
+        Mission = generic_request::Mission,
+        Position = generic_request::Position,
+        Trip = generic_request::Trip,
+    >,
+    T: for<'a> TimetablesIter<'a> + Debug,
+    T::Mission: 'static,
+    T::Position: 'static,
+{
+    utils::init_logger();
+
+    let model = ModelBuilder::new("2020-01-01", "2020-01-02")
+        .vj("first", |vj_builder| {
+            vj_builder
+                .st("A", "10:00:00")
+                .st("B", "10:05:00")
+                .st("C", "10:10:00");
+        })
+        .build();
+
+    let base_model = BaseModel::from_transit_model(model);
+
+    let mut real_time_model = RealTimeModel::new();
+
+    let config = Config::new("2020-01-01T09:50:00", "A", "C");
+    let request_input = utils::make_request_from_config(&config)?;
+    let loads_data = loki::LoadsData::empty();
+
+    let mut data = launch::read::build_transit_data::<T>(
+        &base_model,
+        &loads_data,
+        &config.default_transfer_duration,
+    );
+
+    let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());
+
+    {
+        let model_refs = ModelRefs::new(&base_model, &real_time_model);
+        let responses = solver.solve_request(
+            &data,
+            &model_refs,
+            &request_input,
+            None,
+            &config.comparator_type,
+            &config.datetime_represent,
+        )?;
+
+        assert_eq!(responses.len(), 1);
+        let journey = &responses[0];
+        assert_eq!(
+            model_refs.vehicle_journey_name(&journey.first_vehicle.vehicle_journey),
+            "first"
+        );
+    }
+
+    {
+        let disruption = {
+            let stop_times = StopTimesBuilder::new()
+                .st("A", "09:45:00")
+                .st("B", "10:05:00")
+                .st("C", "10:10:00");
+            modify(&"first", "2020-01-01", stop_times)
+        };
+        real_time_model.apply_disruption(&disruption, &base_model, &loads_data, &mut data);
+    }
+
+    {
+        let mut request_input = request_input.clone();
+        request_input.real_time_level = RealTimeLevel::RealTime;
+
+        let model_refs = ModelRefs::new(&base_model, &real_time_model);
+
+        let responses = solver.solve_request(
+            &data,
+            &model_refs,
+            &request_input,
+            None,
+            &config.comparator_type,
+            &config.datetime_represent,
+        )?;
+
+        // the request is to depart at 9:50, but the vehicle depart at 9:45 at the real time level
+        // so we should not obtain any result
+        assert_eq!(responses.len(), 0);
+    }
+
+    {
+        let model_refs = ModelRefs::new(&base_model, &real_time_model);
+
+        let responses = solver.solve_request(
+            &data,
+            &model_refs,
+            &request_input,
+            None,
+            &config.comparator_type,
+            &config.datetime_represent,
+        )?;
+
+        // the request is to depart at 9:50,
+        // the vehicle depart at 9:45 at the real time level, but its departure is still at 10:00 at the base level
+        // so we should obtain a result
+        assert_eq!(responses.len(), 1);
+        let journey = &responses[0];
+        assert_eq!(
+            model_refs.vehicle_journey_name(&journey.first_vehicle.vehicle_journey),
+            "first"
         );
     }
 

--- a/launch/tests/update_data_test.rs
+++ b/launch/tests/update_data_test.rs
@@ -143,7 +143,8 @@ where
         .unwrap();
 
     {
-        let request_input = utils::make_request_from_config(&config)?;
+        let mut request_input = utils::make_request_from_config(&config)?;
+        request_input.real_time_level = RealTimeLevel::RealTime;
         let responses = solver.solve_request(
             &data,
             &model_refs,
@@ -273,7 +274,8 @@ where
     }
 
     {
-        let request_input = utils::make_request_from_config(&config)?;
+        let mut request_input = utils::make_request_from_config(&config)?;
+        request_input.real_time_level = RealTimeLevel::RealTime;
         let responses = solver.solve_request(
             &data,
             &model_refs,
@@ -299,7 +301,8 @@ where
     }
 
     {
-        let request_input = utils::make_request_from_config(&config)?;
+        let mut request_input = utils::make_request_from_config(&config)?;
+        request_input.real_time_level = RealTimeLevel::RealTime;
         let responses = solver.solve_request(
             &data,
             &model_refs,
@@ -325,7 +328,8 @@ where
     }
 
     {
-        let request_input = utils::make_request_from_config(&config)?;
+        let mut request_input = utils::make_request_from_config(&config)?;
+        request_input.real_time_level = RealTimeLevel::RealTime;
         let responses = solver.solve_request(
             &data,
             &model_refs,

--- a/launch/tests/utils/disruption_builder.rs
+++ b/launch/tests/utils/disruption_builder.rs
@@ -1,0 +1,94 @@
+// Copyright (C) 2017 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License as published by the
+// Free Software Foundation, version 3.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+// details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>
+
+use loki::{
+    chrono::NaiveDate,
+    models::real_time_disruption::{Disruption, StopTime, Trip, Update},
+    time::SecondsSinceTimezonedDayStart,
+};
+
+use super::model_builder::{AsDate, IntoTime};
+
+pub fn delete(vehicle_journey_id: String, date: NaiveDate) -> Disruption {
+    let trip = Trip {
+        vehicle_journey_id: vehicle_journey_id.clone(),
+        reference_date: date,
+    };
+    let update = Update::Delete(trip);
+    Disruption {
+        id: format!("Delete {} {}", vehicle_journey_id, date),
+        updates: vec![update],
+    }
+}
+
+pub fn add(
+    vehicle_journey_id: String,
+    date: NaiveDate,
+    stop_times_builder: StopTimesBuilder,
+) -> Disruption {
+    let trip = Trip {
+        vehicle_journey_id: vehicle_journey_id.clone(),
+        reference_date: date,
+    };
+    let update = Update::Add(trip, stop_times_builder.stop_times);
+    Disruption {
+        id: format!("Add {} {}", vehicle_journey_id, date),
+        updates: vec![update],
+    }
+}
+
+pub fn modify(
+    vehicle_journey_id: &str,
+    date: impl AsDate,
+    stop_times_builder: StopTimesBuilder,
+) -> Disruption {
+    let trip = Trip {
+        vehicle_journey_id: vehicle_journey_id.to_string(),
+        reference_date: date.as_date(),
+    };
+    let update = Update::Modify(trip, stop_times_builder.stop_times);
+    Disruption {
+        id: format!("Modify {} {}", vehicle_journey_id, date.as_date()),
+        updates: vec![update],
+    }
+}
+
+pub struct DisruptionBuilder {}
+
+pub struct StopTimesBuilder {
+    stop_times: Vec<StopTime>,
+}
+
+impl StopTimesBuilder {
+    pub fn new() -> Self {
+        Self {
+            stop_times: Vec::new(),
+        }
+    }
+
+    pub fn st(mut self, stop_id: &str, time: impl IntoTime) -> Self {
+        let time = SecondsSinceTimezonedDayStart::from_seconds_i64(i64::from(
+            time.into_time().total_seconds(),
+        ))
+        .unwrap();
+        let stop_time = StopTime {
+            stop_id: stop_id.to_string(),
+            arrival_time: time.clone(),
+            departure_time: time.clone(),
+            flow_direction: loki::timetables::FlowDirection::BoardAndDebark,
+        };
+        self.stop_times.push(stop_time);
+        self
+    }
+}

--- a/launch/tests/utils/mod.rs
+++ b/launch/tests/utils/mod.rs
@@ -60,7 +60,7 @@ use loki::{
     TransitData,
 };
 use model_builder::AsDateTime;
-use std::fmt::Debug;
+
 
 pub fn init_logger() {
     let _ = env_logger::Builder::from_env(
@@ -180,7 +180,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    Timetables: for<'a> TimetablesIter<'a> + Debug,
+    Timetables: for<'a> TimetablesIter<'a> ,
     Timetables::Mission: 'static,
     Timetables::Position: 'static,
 {

--- a/launch/tests/utils/mod.rs
+++ b/launch/tests/utils/mod.rs
@@ -184,12 +184,8 @@ where
     Timetables::Position: 'static,
 {
     use loki::DataTrait;
-    let data: TransitData<Timetables> = launch::read::build_transit_data(
-        model.base,
-        loads_data,
-        &config.default_transfer_duration,
-        None,
-    );
+    let data: TransitData<Timetables> =
+        launch::read::build_transit_data(model.base, loads_data, &config.default_transfer_duration);
 
     let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());
 

--- a/launch/tests/utils/mod.rs
+++ b/launch/tests/utils/mod.rs
@@ -61,7 +61,6 @@ use loki::{
 };
 use model_builder::AsDateTime;
 
-
 pub fn init_logger() {
     let _ = env_logger::Builder::from_env(
         // use log level specified by RUST_LOG env var if set
@@ -180,7 +179,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    Timetables: for<'a> TimetablesIter<'a> ,
+    Timetables: for<'a> TimetablesIter<'a>,
     Timetables::Mission: 'static,
     Timetables::Position: 'static,
 {

--- a/launch/tests/utils/mod.rs
+++ b/launch/tests/utils/mod.rs
@@ -34,6 +34,7 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 #![allow(dead_code)]
+pub mod disruption_builder;
 pub mod model_builder;
 
 use env_logger::Env;

--- a/launch/tests/utils/mod.rs
+++ b/launch/tests/utils/mod.rs
@@ -147,6 +147,7 @@ pub fn make_request_from_config(config: &Config) -> Result<RequestInput, Error> 
         max_nb_of_legs: config.request_params.max_nb_of_legs,
         max_journey_duration: config.request_params.max_journey_duration,
         too_late_threshold: config.request_params.too_late_threshold,
+        real_time_level: config.request_params.real_time_level.clone(),
     };
     Ok(request_input)
 }

--- a/random/src/main.rs
+++ b/random/src/main.rs
@@ -157,7 +157,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    Timetables: for<'a> TimetablesIter<'a> ,
+    Timetables: for<'a> TimetablesIter<'a>,
     Timetables::Mission: 'static,
     Timetables::Position: 'static,
 {

--- a/random/src/main.rs
+++ b/random/src/main.rs
@@ -18,7 +18,6 @@ use failure::{bail, Error};
 
 use launch::datetime::DateTimeRepresent;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 use structopt::StructOpt;
 
 fn main() {
@@ -158,7 +157,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    Timetables: for<'a> TimetablesIter<'a> + Debug,
+    Timetables: for<'a> TimetablesIter<'a> ,
     Timetables::Mission: 'static,
     Timetables::Position: 'static,
 {
@@ -177,7 +176,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    Timetables: for<'a> TimetablesIter<'a> + Debug,
+    Timetables: for<'a> TimetablesIter<'a>,
     Timetables::Mission: 'static,
     Timetables::Position: 'static,
 {

--- a/server/src/compute_worker.rs
+++ b/server/src/compute_worker.rs
@@ -36,7 +36,6 @@
 
 use failure::{format_err, Error};
 use std::{
-    fmt::Debug,
     ops::Deref,
     sync::{Arc, RwLock},
 };
@@ -210,7 +209,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    Timetables: for<'a> TimetablesIter<'a> + Debug,
+    Timetables: for<'a> TimetablesIter<'a> ,
     Timetables::Mission: 'static,
     Timetables::Position: 'static,
 {

--- a/server/src/compute_worker.rs
+++ b/server/src/compute_worker.rs
@@ -398,6 +398,7 @@ where
         max_nb_of_legs,
         max_journey_duration,
         too_late_threshold: request_default_params.too_late_threshold,
+        real_time_level: request_default_params.real_time_level.clone(),
     };
 
     let datetime_represent = match journey_request.clockwise {

--- a/server/src/compute_worker.rs
+++ b/server/src/compute_worker.rs
@@ -173,7 +173,7 @@ impl ComputeWorker {
                     })?;
 
                 let (data, base_model, real_time_model) = rw_lock_read_guard.deref();
-                let model_refs = ModelRefs::new(base_model, &real_time_model);
+                let model_refs = ModelRefs::new(base_model, real_time_model);
 
                 let solve_result = solve(
                     journey_request,

--- a/server/src/compute_worker.rs
+++ b/server/src/compute_worker.rs
@@ -209,7 +209,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    Timetables: for<'a> TimetablesIter<'a> ,
+    Timetables: for<'a> TimetablesIter<'a>,
     Timetables::Mission: 'static,
     Timetables::Position: 'static,
 {

--- a/server/src/load_balancer.rs
+++ b/server/src/load_balancer.rs
@@ -51,7 +51,7 @@ use tokio::{runtime::Builder, sync::mpsc};
 
 use crate::{
     compute_worker::ComputeWorker,
-    master_worker::{BaseTimetable, LoadBalancerChannels, LoadBalancerOrder, RealTimeTimetable},
+    master_worker::{LoadBalancerChannels, LoadBalancerOrder, Timetable},
     zmq_worker::{RequestMessage, ResponseMessage, ZmqWorker, ZmqWorkerChannels},
 };
 
@@ -88,8 +88,7 @@ pub struct LoadBalancer {
 
 impl LoadBalancer {
     pub fn new(
-        base_data_and_model: Arc<RwLock<(TransitData<BaseTimetable>, BaseModel)>>,
-        real_time_data_and_model: Arc<RwLock<(TransitData<RealTimeTimetable>, RealTimeModel)>>,
+        data_and_models: Arc<RwLock<(TransitData<Timetable>, BaseModel, RealTimeModel)>>,
         nb_workers: usize,
         zmq_endpoint: &str,
         request_default_params: &config::RequestParams,
@@ -106,8 +105,7 @@ impl LoadBalancer {
 
             let (worker, request_channel) = ComputeWorker::new(
                 worker_id,
-                base_data_and_model.clone(),
-                real_time_data_and_model.clone(),
+                data_and_models.clone(),
                 request_default_params.clone(),
                 workers_response_sender.clone(),
             );

--- a/server/src/master_worker.rs
+++ b/server/src/master_worker.rs
@@ -90,7 +90,6 @@ impl MasterWorker {
             &base_model,
             &loads_data,
             &launch_params.default_transfer_duration,
-            None,
         );
         info!("Data loaded");
 

--- a/server/src/master_worker.rs
+++ b/server/src/master_worker.rs
@@ -37,14 +37,13 @@
 use super::chaos_proto::gtfs_realtime;
 use failure::{format_err, Error};
 use launch::loki::{
-    chrono,
     models::{base_model::BaseModel, real_time_model::RealTimeModel},
-    timetables::{DailyTimetables, PeriodicSplitVjByTzTimetables},
+    timetables::PeriodicSplitVjByTzTimetables,
     tracing::{debug, error, info},
-    DataTrait, LoadsData, TransitData,
+    LoadsData, TransitData,
 };
 use std::{
-    ops::{Deref, DerefMut},
+    ops::DerefMut,
     sync::{Arc, RwLock},
 };
 use tokio::{
@@ -65,8 +64,7 @@ pub enum LoadBalancerOrder {
     Stop,
 }
 
-pub type BaseTimetable = PeriodicSplitVjByTzTimetables;
-pub type RealTimeTimetable = DailyTimetables;
+pub type Timetable = PeriodicSplitVjByTzTimetables;
 
 pub struct LoadBalancerChannels {
     pub load_balancer_order_sender: mpsc::Sender<LoadBalancerOrder>,
@@ -75,53 +73,35 @@ pub struct LoadBalancerChannels {
 }
 
 pub struct MasterWorker {
-    base_data_and_model: Arc<RwLock<(TransitData<BaseTimetable>, BaseModel)>>,
-    real_time_data_and_model: Arc<RwLock<(TransitData<RealTimeTimetable>, RealTimeModel)>>,
+    data_and_models: Arc<RwLock<(TransitData<Timetable>, BaseModel, RealTimeModel)>>,
     loads_data: LoadsData,
     amqp_message_receiver: mpsc::Receiver<Vec<gtfs_realtime::FeedMessage>>,
     load_balancer_handle: LoadBalancerChannels,
-    nb_of_realtime_days_to_keep: u16,
 }
 
 impl MasterWorker {
     pub fn new(config: &Config) -> Result<Self, Error> {
         let launch_params = &config.launch_params;
         let base_model = launch::read::read_model(launch_params)?;
-        info!("Base model loaded");
-        info!("Starting to build base data");
+        info!("Model loaded");
+        info!("Starting to build data");
         let loads_data = launch::read::read_loads_data(launch_params, &base_model);
-        let base_data = launch::read::build_transit_data::<BaseTimetable>(
+        let data = launch::read::build_transit_data::<Timetable>(
             &base_model,
             &loads_data,
             &launch_params.default_transfer_duration,
             None,
         );
-        info!("Base data loaded");
-        let restrict_calendar_for_realtime = {
-            let start_date = *base_data.calendar().first_date();
-            let end_date = start_date + chrono::Duration::days(2);
-            Some((start_date, end_date))
-        };
-
-        info!("Starting to build real time data");
-        let real_time_model = RealTimeModel::new();
-        let real_time_data = launch::read::build_transit_data::<RealTimeTimetable>(
-            &base_model,
-            &loads_data,
-            &launch_params.default_transfer_duration,
-            restrict_calendar_for_realtime,
-        );
-        info!("Real time data loaded");
+        info!("Data loaded");
 
         info!("Starting to build workers");
 
-        let base_data_and_model = Arc::new(RwLock::new((base_data, base_model)));
-        let real_time_data_and_model = Arc::new(RwLock::new((real_time_data, real_time_model)));
+        let real_time_model = RealTimeModel::new();
+        let data_and_models = Arc::new(RwLock::new((data, base_model, real_time_model)));
 
         // LoadBalancer worker
         let (load_balancer, load_balancer_handle) = LoadBalancer::new(
-            base_data_and_model.clone(),
-            real_time_data_and_model.clone(),
+            data_and_models.clone(),
             config.nb_workers,
             &config.requests_socket,
             &config.request_default_params,
@@ -137,12 +117,10 @@ impl MasterWorker {
 
         // Master worker
         let result = Self {
-            base_data_and_model,
-            real_time_data_and_model,
+            data_and_models,
             loads_data,
             amqp_message_receiver,
             load_balancer_handle,
-            nb_of_realtime_days_to_keep: config.nb_of_realtime_days_to_keep,
         };
         Ok(result)
     }
@@ -240,22 +218,14 @@ impl MasterWorker {
         &mut self,
         messages: Vec<gtfs_realtime::FeedMessage>,
     ) -> Result<(), Error> {
-        let base_lock_guard = self.base_data_and_model.read().map_err(|err| {
+        let mut lock_guard = self.data_and_models.write().map_err(|err| {
             format_err!(
-                "Master worker failed to acquire read lock on base_time_data_and_model. {}.",
+                "Master worker failed to acquire write lock on data_and_models. {}.",
                 err
             )
         })?;
 
-        let mut real_time_lock_guard = self.real_time_data_and_model.write().map_err(|err| {
-            format_err!(
-                "Master worker failed to acquire write lock on real_time_data_and_model. {}.",
-                err
-            )
-        })?;
-
-        let (_, base_model) = base_lock_guard.deref();
-        let (real_time_data, real_time_model) = real_time_lock_guard.deref_mut();
+        let (data, base_model, real_time_model) = lock_guard.deref_mut();
 
         for message in messages.into_iter() {
             for feed_entity in message.entity {
@@ -269,7 +239,7 @@ impl MasterWorker {
                             &disruption,
                             base_model,
                             &self.loads_data,
-                            real_time_data,
+                            data,
                         );
                     }
                 }

--- a/server/src/master_worker.rs
+++ b/server/src/master_worker.rs
@@ -39,7 +39,7 @@ use failure::{format_err, Error};
 use launch::loki::{
     chrono,
     models::{base_model::BaseModel, real_time_model::RealTimeModel},
-    timetables::PeriodicSplitVjByTzTimetables,
+    timetables::{DailyTimetables, PeriodicSplitVjByTzTimetables},
     tracing::{debug, error, info},
     DataTrait, LoadsData, TransitData,
 };

--- a/server/src/master_worker.rs
+++ b/server/src/master_worker.rs
@@ -39,7 +39,7 @@ use failure::{format_err, Error};
 use launch::loki::{
     chrono,
     models::{base_model::BaseModel, real_time_model::RealTimeModel},
-    timetables::{DailyTimetables, PeriodicSplitVjByTzTimetables},
+    timetables::PeriodicSplitVjByTzTimetables,
     tracing::{debug, error, info},
     DataTrait, LoadsData, TransitData,
 };
@@ -270,7 +270,6 @@ impl MasterWorker {
                             base_model,
                             &self.loads_data,
                             real_time_data,
-                            self.nb_of_realtime_days_to_keep,
                         );
                     }
                 }

--- a/src/engine/engine_interface.rs
+++ b/src/engine/engine_interface.rs
@@ -1,4 +1,8 @@
-use crate::{models::ModelRefs, response, transit_data::data_interface::{self, RealTimeLevel}};
+use crate::{
+    models::ModelRefs,
+    response,
+    transit_data::data_interface::{self, RealTimeLevel},
+};
 
 pub trait RequestTypes: data_interface::TransitTypes {
     /// Identify a possible departure of a journey
@@ -240,7 +244,7 @@ pub struct RequestInput {
     pub max_nb_of_legs: u8,
     pub max_journey_duration: PositiveDuration,
     pub too_late_threshold: PositiveDuration,
-    pub real_time_level : RealTimeLevel,
+    pub real_time_level: RealTimeLevel,
 }
 
 pub trait RequestIO<'data, 'model, Data: data_interface::Data>: Request {

--- a/src/engine/engine_interface.rs
+++ b/src/engine/engine_interface.rs
@@ -234,7 +234,7 @@ pub trait RequestIters<'a>: RequestTypes {
     fn trips_of(&'a self, mission: &Self::Mission) -> Self::TripsOfMission;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RequestInput {
     pub datetime: NaiveDateTime,
     pub departures_stop_point_and_fallback_duration: Vec<(String, PositiveDuration)>,

--- a/src/engine/engine_interface.rs
+++ b/src/engine/engine_interface.rs
@@ -231,7 +231,11 @@ pub trait RequestIters<'a>: RequestTypes {
     /// Iterator for all `Trip`s belonging to a `Mission`.
     type TripsOfMission: Iterator<Item = Self::Trip>;
     /// Returns all `Trip`s belonging to `mission`
-    fn trips_of(&'a self, mission: &Self::Mission, real_time_level : &RealTimeLevel) -> Self::TripsOfMission;
+    fn trips_of(
+        &'a self,
+        mission: &Self::Mission,
+        real_time_level: &RealTimeLevel,
+    ) -> Self::TripsOfMission;
 }
 
 #[derive(Debug, Clone)]

--- a/src/engine/engine_interface.rs
+++ b/src/engine/engine_interface.rs
@@ -1,4 +1,4 @@
-use crate::{models::ModelRefs, response, transit_data::data_interface};
+use crate::{models::ModelRefs, response, transit_data::data_interface::{self, RealTimeLevel}};
 
 pub trait RequestTypes: data_interface::TransitTypes {
     /// Identify a possible departure of a journey
@@ -240,6 +240,7 @@ pub struct RequestInput {
     pub max_nb_of_legs: u8,
     pub max_journey_duration: PositiveDuration,
     pub too_late_threshold: PositiveDuration,
+    pub real_time_level : RealTimeLevel,
 }
 
 pub trait RequestIO<'data, 'model, Data: data_interface::Data>: Request {

--- a/src/engine/engine_interface.rs
+++ b/src/engine/engine_interface.rs
@@ -231,7 +231,7 @@ pub trait RequestIters<'a>: RequestTypes {
     /// Iterator for all `Trip`s belonging to a `Mission`.
     type TripsOfMission: Iterator<Item = Self::Trip>;
     /// Returns all `Trip`s belonging to `mission`
-    fn trips_of(&'a self, mission: &Self::Mission) -> Self::TripsOfMission;
+    fn trips_of(&'a self, mission: &Self::Mission, real_time_level : &RealTimeLevel) -> Self::TripsOfMission;
 }
 
 #[derive(Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ pub use transit_data::data_interface::{
     Data as DataTrait, DataIO, DataUpdate, DataWithIters, TransitTypes, RealTimeLevel,
 };
 
-// pub type DailyData = timetables::DailyTimetables;
-// pub type PeriodicData = timetables::PeriodicTimetables;
+pub type DailyData = timetables::DailyTimetables;
+pub type PeriodicData = timetables::PeriodicTimetables;
 pub type PeriodicSplitVjData = timetables::PeriodicSplitVjByTzTimetables;
 
 pub use loads_data::LoadsData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ pub use transit_data::data_interface::{
     Data as DataTrait, DataIO, DataUpdate, DataWithIters, TransitTypes,
 };
 
-pub type DailyData = timetables::DailyTimetables;
-pub type PeriodicData = timetables::PeriodicTimetables;
+// pub type DailyData = timetables::DailyTimetables;
+// pub type PeriodicData = timetables::PeriodicTimetables;
 pub type PeriodicSplitVjData = timetables::PeriodicSplitVjByTzTimetables;
 
 pub use loads_data::LoadsData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub use transit_model;
 pub use typed_index_collection;
 
 pub use transit_data::data_interface::{
-    Data as DataTrait, DataIO, DataUpdate, DataWithIters, TransitTypes,
+    Data as DataTrait, DataIO, DataUpdate, DataWithIters, TransitTypes, RealTimeLevel,
 };
 
 // pub type DailyData = timetables::DailyTimetables;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ pub use transit_data::data_interface::{
     Data as DataTrait, DataIO, DataUpdate, DataWithIters, RealTimeLevel, TransitTypes,
 };
 
-pub type DailyData = timetables::DailyTimetables;
-pub type PeriodicData = timetables::PeriodicTimetables;
+pub type DailyData = timetables::PeriodicSplitVjByTzTimetables;
+pub type PeriodicData = timetables::PeriodicSplitVjByTzTimetables;
 pub type PeriodicSplitVjData = timetables::PeriodicSplitVjByTzTimetables;
 
 pub use loads_data::LoadsData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ pub use transit_data::data_interface::{
     Data as DataTrait, DataIO, DataUpdate, DataWithIters, RealTimeLevel, TransitTypes,
 };
 
-pub type DailyData = timetables::PeriodicSplitVjByTzTimetables;
-pub type PeriodicData = timetables::PeriodicSplitVjByTzTimetables;
+pub type DailyData = timetables::DailyTimetables;
+pub type PeriodicData = timetables::PeriodicTimetables;
 pub type PeriodicSplitVjData = timetables::PeriodicSplitVjByTzTimetables;
 
 pub use loads_data::LoadsData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub use transit_model;
 pub use typed_index_collection;
 
 pub use transit_data::data_interface::{
-    Data as DataTrait, DataIO, DataUpdate, DataWithIters, TransitTypes, RealTimeLevel,
+    Data as DataTrait, DataIO, DataUpdate, DataWithIters, RealTimeLevel, TransitTypes,
 };
 
 pub type DailyData = timetables::DailyTimetables;

--- a/src/models.rs
+++ b/src/models.rs
@@ -48,7 +48,7 @@ use self::{
     real_time_model::{NewStopPointIdx, NewVehicleJourneyIdx},
 };
 
-#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub enum VehicleJourneyIdx {
     Base(BaseVehicleJourneyIdx),
     New(NewVehicleJourneyIdx),

--- a/src/models/real_time_model.rs
+++ b/src/models/real_time_model.rs
@@ -150,7 +150,7 @@ impl RealTimeModel {
                     .real_time_level(trip, base_model)
                     .map_err(|_| UpdateError::DeleteAbsentTrip(trip.clone()))?;
                 let removal_result =
-                    data.remove_vehicle(&vj_idx, &trip.reference_date, &real_time_level);
+                    data.remove_vehicle(&vj_idx, &trip.reference_date, real_time_level);
                 if let Err(removal_error) = removal_result {
                     let model_ref = ModelRefs {
                         base: base_model,
@@ -172,7 +172,7 @@ impl RealTimeModel {
                 let flows = stop_times.iter().map(|stop_time| stop_time.flow_direction);
                 let board_times = stop_times.iter().map(|stop_time| stop_time.departure_time);
                 let debark_times = stop_times.iter().map(|stop_time| stop_time.arrival_time);
-                let insertion_errors = data.add_vehicle(
+                let insertion_errors = data.add_real_time_vehicle(
                     stops,
                     flows,
                     board_times,

--- a/src/models/real_time_model.rs
+++ b/src/models/real_time_model.rs
@@ -310,41 +310,6 @@ impl RealTimeModel {
         }
     }
 
-    fn real_time_level(
-        &self,
-        trip: &disruption::Trip,
-        base_model: &BaseModel,
-    ) -> Result<RealTimeLevel, ()> {
-        if let Some(transit_model_idx) = base_model
-            .vehicle_journeys
-            .get_idx(&trip.vehicle_journey_id)
-        {
-            if self
-                .base_vehicle_journey_last_version(&transit_model_idx, &trip.reference_date)
-                .is_some()
-            {
-                Ok(RealTimeLevel::RealTime)
-            } else {
-                Ok(RealTimeLevel::Base)
-            }
-        } else if let Some(new_vj_idx) = self
-            .new_vehicle_journeys_id_to_idx
-            .get(&trip.vehicle_journey_id)
-        {
-            if self
-                .new_vehicle_journey_last_version(new_vj_idx, &trip.reference_date)
-                .is_some()
-            {
-                Ok(RealTimeLevel::RealTime)
-            } else {
-                Err(())
-            }
-        } else {
-            //
-            Err(())
-        }
-    }
-
     fn set_version(
         &mut self,
         trip: &disruption::Trip,

--- a/src/models/real_time_model.rs
+++ b/src/models/real_time_model.rs
@@ -43,8 +43,8 @@ use crate::{
     time::SecondsSinceTimezonedDayStart,
     timetables::FlowDirection,
     transit_data::{
-        data_interface::{Data as DataTrait, RealTimeLevel},
-        handle_insertion_error, handle_modify_error, handle_removal_error,
+        data_interface::Data as DataTrait, handle_insertion_error, handle_modify_error,
+        handle_removal_error,
     },
 };
 

--- a/src/models/real_time_model.rs
+++ b/src/models/real_time_model.rs
@@ -38,7 +38,15 @@ use std::{collections::HashMap, hash::Hash};
 
 use tracing::error;
 
-use crate::{chrono::NaiveDate, time::SecondsSinceTimezonedDayStart, timetables::{FlowDirection}, transit_data::{data_interface::{Data as DataTrait, RealTimeLevel}, handle_insertion_error, handle_modify_error, handle_removal_error}};
+use crate::{
+    chrono::NaiveDate,
+    time::SecondsSinceTimezonedDayStart,
+    timetables::FlowDirection,
+    transit_data::{
+        data_interface::{Data as DataTrait, RealTimeLevel},
+        handle_insertion_error, handle_modify_error, handle_removal_error,
+    },
+};
 
 use crate::{DataUpdate, LoadsData};
 
@@ -104,7 +112,6 @@ pub enum UpdateError {
     ModifyAbsentTrip(disruption::Trip),
     AddPresentTrip(disruption::Trip),
 }
-
 
 impl RealTimeModel {
     pub fn apply_disruption<Data: DataTrait + DataUpdate>(
@@ -172,8 +179,7 @@ impl RealTimeModel {
 
             disruption::Update::Delete(trip) => {
                 let vj_idx = self.delete(disruption_id, trip, base_model)?;
-                let removal_result =
-                    data.remove_real_time_vehicle(&vj_idx, &trip.reference_date);
+                let removal_result = data.remove_real_time_vehicle(&vj_idx, &trip.reference_date);
                 if let Err(removal_error) = removal_result {
                     let model_ref = ModelRefs {
                         base: base_model,
@@ -219,7 +225,6 @@ impl RealTimeModel {
                         data.calendar().last_date(),
                         &err,
                     );
-
                 }
                 Ok(())
             }

--- a/src/models/real_time_model.rs
+++ b/src/models/real_time_model.rs
@@ -301,13 +301,12 @@ impl RealTimeModel {
             .vehicle_journeys
             .get_idx(&trip.vehicle_journey_id)
         {
-            if let Some(&TripData::Deleted()) =
-                self.base_vehicle_journey_last_version(&transit_model_idx, &trip.reference_date)
-            {
-                false
-            } else {
-                true
-            }
+            use std::ops::Not;
+            matches!(
+                self.base_vehicle_journey_last_version(&transit_model_idx, &trip.reference_date),
+                Some(&TripData::Deleted())
+            )
+            .not()
         } else {
             self.new_vehicle_journeys_id_to_idx
                 .contains_key(&trip.vehicle_journey_id)

--- a/src/models/real_time_model.rs
+++ b/src/models/real_time_model.rs
@@ -195,7 +195,7 @@ impl RealTimeModel {
                 Ok(())
             }
             disruption::Update::Modify(trip, stop_times) => {
-                let (vj_idx, real_time_level, stop_times) =
+                let (vj_idx, stop_times) =
                     self.modify(disruption_id, trip, stop_times, base_model)?;
                 let dates = std::iter::once(&trip.reference_date);
                 let stops = stop_times.iter().map(|stop_time| stop_time.stop.clone());
@@ -278,21 +278,18 @@ impl RealTimeModel {
         trip: &disruption::Trip,
         stop_times: &[disruption::StopTime],
         base_model: &BaseModel,
-    ) -> Result<(VehicleJourneyIdx, RealTimeLevel, Vec<StopTime>), UpdateError> {
+    ) -> Result<(VehicleJourneyIdx, Vec<StopTime>), UpdateError> {
         if !self.is_present(trip, base_model) {
             let err = UpdateError::ModifyAbsentTrip(trip.clone());
             Err(err)
         } else {
-            let real_time_level = self
-                .real_time_level(trip, base_model)
-                .map_err(|_| UpdateError::ModifyAbsentTrip(trip.clone()))?;
             let stop_times = self.make_stop_times(stop_times, base_model);
             let trip_version = TripVersion {
                 disruption_id: disruption_id.to_string(),
                 trip_data: TripData::Present(stop_times.clone()),
             };
             let idx = self.set_version(trip, base_model, trip_version);
-            Ok((idx, real_time_level, stop_times))
+            Ok((idx, stop_times))
         }
     }
 

--- a/src/request/arrive_before.rs
+++ b/src/request/arrive_before.rs
@@ -482,8 +482,8 @@ where
         }
     }
 
-    fn trips_of(&'outer self, mission: &Data::Mission) -> Data::TripsOfMission {
-        self.transit_data.trips_of(mission)
+    fn trips_of(&'outer self, mission: &Data::Mission, real_time_level : &RealTimeLevel) -> Data::TripsOfMission {
+        self.transit_data.trips_of(mission, real_time_level)
     }
 }
 

--- a/src/request/arrive_before.rs
+++ b/src/request/arrive_before.rs
@@ -42,6 +42,7 @@ use crate::{
     models::ModelRefs,
     time::{PositiveDuration, SecondsSinceDatasetUTCStart},
     transit_data::data_interface::DataIters,
+    RealTimeLevel,
 };
 
 use crate::{
@@ -60,6 +61,7 @@ pub struct GenericArriveBeforeRequest<'data, 'model, Data: DataTrait> {
     pub(super) min_departure_time: SecondsSinceDatasetUTCStart,
     pub(super) max_nb_legs: u8,
     pub(super) too_late_threshold: PositiveDuration,
+    pub(super) real_time_level: RealTimeLevel,
 }
 
 impl<'data, 'model, Data> GenericArriveBeforeRequest<'data, 'model, Data>
@@ -102,6 +104,7 @@ where
             min_departure_time: arrival_datetime - request_input.max_journey_duration,
             max_nb_legs: request_input.max_nb_of_legs,
             too_late_threshold: request_input.too_late_threshold,
+            real_time_level: request_input.real_time_level.clone(),
         };
 
         Ok(result)
@@ -263,7 +266,7 @@ where
     ) -> Option<(Data::Trip, Criteria)> {
         let waiting_time = &waiting_criteria.time;
         self.transit_data
-            .latest_trip_that_debark_at(waiting_time, mission, position)
+            .latest_trip_that_debark_at(waiting_time, mission, position, &self.real_time_level)
             .map(|(trip, debark_time, load)| {
                 let new_criteria = Criteria {
                     time: debark_time,
@@ -400,7 +403,7 @@ where
         let mission = &self.transit_data.mission_of(trip);
         let (new_trip, _, _) = self
             .transit_data
-            .earliest_trip_to_board_at(&board_time, mission, board_position)
+            .earliest_trip_to_board_at(&board_time, mission, board_position, &self.real_time_level)
             .ok_or_else(|| NoTrip(board_time, mission.clone(), board_position.clone()))?;
         *trip = new_trip;
         let debark_time = self

--- a/src/request/arrive_before.rs
+++ b/src/request/arrive_before.rs
@@ -482,7 +482,11 @@ where
         }
     }
 
-    fn trips_of(&'outer self, mission: &Data::Mission, real_time_level : &RealTimeLevel) -> Data::TripsOfMission {
+    fn trips_of(
+        &'outer self,
+        mission: &Data::Mission,
+        real_time_level: &RealTimeLevel,
+    ) -> Data::TripsOfMission {
         self.transit_data.trips_of(mission, real_time_level)
     }
 }

--- a/src/request/arrive_before/basic_comparator.rs
+++ b/src/request/arrive_before/basic_comparator.rs
@@ -34,14 +34,10 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use crate::{
-    engine::engine_interface::{
+use crate::{RealTimeLevel, engine::engine_interface::{
         BadRequest, Request as RequestTrait, RequestDebug, RequestIO, RequestInput, RequestIters,
         RequestTypes, RequestWithIters,
-    },
-    models::ModelRefs,
-    transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes},
-};
+    }, models::ModelRefs, transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes}};
 
 use super::{Arrival, Arrivals, Criteria, Departure, Departures, GenericArriveBeforeRequest};
 pub struct Request<'data, 'model, Data: DataTrait> {
@@ -210,8 +206,8 @@ where
     }
 
     type TripsOfMission = Data::TripsOfMission;
-    fn trips_of(&'outer self, mission: &Self::Mission) -> Self::TripsOfMission {
-        self.generic.trips_of(mission)
+    fn trips_of(&'outer self, mission: &Self::Mission, real_time_level : &RealTimeLevel) -> Self::TripsOfMission {
+        self.generic.trips_of(mission, real_time_level)
     }
 }
 

--- a/src/request/arrive_before/basic_comparator.rs
+++ b/src/request/arrive_before/basic_comparator.rs
@@ -34,10 +34,15 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use crate::{RealTimeLevel, engine::engine_interface::{
+use crate::{
+    engine::engine_interface::{
         BadRequest, Request as RequestTrait, RequestDebug, RequestIO, RequestInput, RequestIters,
         RequestTypes, RequestWithIters,
-    }, models::ModelRefs, transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes}};
+    },
+    models::ModelRefs,
+    transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes},
+    RealTimeLevel,
+};
 
 use super::{Arrival, Arrivals, Criteria, Departure, Departures, GenericArriveBeforeRequest};
 pub struct Request<'data, 'model, Data: DataTrait> {
@@ -206,7 +211,11 @@ where
     }
 
     type TripsOfMission = Data::TripsOfMission;
-    fn trips_of(&'outer self, mission: &Self::Mission, real_time_level : &RealTimeLevel) -> Self::TripsOfMission {
+    fn trips_of(
+        &'outer self,
+        mission: &Self::Mission,
+        real_time_level: &RealTimeLevel,
+    ) -> Self::TripsOfMission {
         self.generic.trips_of(mission, real_time_level)
     }
 }

--- a/src/request/arrive_before/loads_comparator.rs
+++ b/src/request/arrive_before/loads_comparator.rs
@@ -34,14 +34,10 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use crate::{
-    engine::engine_interface::{
+use crate::{RealTimeLevel, engine::engine_interface::{
         BadRequest, Request as RequestTrait, RequestDebug, RequestIO, RequestInput, RequestIters,
         RequestTypes, RequestWithIters,
-    },
-    models::ModelRefs,
-    transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes},
-};
+    }, models::ModelRefs, transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes}};
 
 use super::{Arrival, Arrivals, Criteria, Departure, Departures, GenericArriveBeforeRequest};
 pub struct Request<'data, 'model, Data: DataTrait> {
@@ -211,8 +207,8 @@ where
     }
 
     type TripsOfMission = Data::TripsOfMission;
-    fn trips_of(&'outer self, mission: &Self::Mission) -> Self::TripsOfMission {
-        self.generic.trips_of(mission)
+    fn trips_of(&'outer self, mission: &Self::Mission, real_time_level : &RealTimeLevel) -> Self::TripsOfMission {
+        self.generic.trips_of(mission, real_time_level)
     }
 }
 

--- a/src/request/arrive_before/loads_comparator.rs
+++ b/src/request/arrive_before/loads_comparator.rs
@@ -34,10 +34,15 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use crate::{RealTimeLevel, engine::engine_interface::{
+use crate::{
+    engine::engine_interface::{
         BadRequest, Request as RequestTrait, RequestDebug, RequestIO, RequestInput, RequestIters,
         RequestTypes, RequestWithIters,
-    }, models::ModelRefs, transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes}};
+    },
+    models::ModelRefs,
+    transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes},
+    RealTimeLevel,
+};
 
 use super::{Arrival, Arrivals, Criteria, Departure, Departures, GenericArriveBeforeRequest};
 pub struct Request<'data, 'model, Data: DataTrait> {
@@ -207,7 +212,11 @@ where
     }
 
     type TripsOfMission = Data::TripsOfMission;
-    fn trips_of(&'outer self, mission: &Self::Mission, real_time_level : &RealTimeLevel) -> Self::TripsOfMission {
+    fn trips_of(
+        &'outer self,
+        mission: &Self::Mission,
+        real_time_level: &RealTimeLevel,
+    ) -> Self::TripsOfMission {
         self.generic.trips_of(mission, real_time_level)
     }
 }

--- a/src/request/depart_after.rs
+++ b/src/request/depart_after.rs
@@ -474,7 +474,11 @@ where
         }
     }
 
-    fn trips_of(&'outer self, mission: &Data::Mission, real_time_level : &RealTimeLevel) -> Data::TripsOfMission {
+    fn trips_of(
+        &'outer self,
+        mission: &Data::Mission,
+        real_time_level: &RealTimeLevel,
+    ) -> Data::TripsOfMission {
         self.transit_data.trips_of(mission, real_time_level)
     }
 }

--- a/src/request/depart_after.rs
+++ b/src/request/depart_after.rs
@@ -42,6 +42,7 @@ use crate::{
     models::ModelRefs,
     time::{PositiveDuration, SecondsSinceDatasetUTCStart},
     transit_data::data_interface::DataIters,
+    RealTimeLevel,
 };
 
 use crate::{
@@ -71,6 +72,7 @@ pub struct GenericDepartAfterRequest<'data, 'model, Data: DataTrait> {
     pub(super) max_arrival_time: SecondsSinceDatasetUTCStart,
     pub(super) max_nb_legs: u8,
     pub(super) too_late_threshold: PositiveDuration,
+    pub(super) real_time_level: RealTimeLevel,
 }
 
 impl<'data, 'model, Data> GenericDepartAfterRequest<'data, 'model, Data>
@@ -113,6 +115,7 @@ where
             max_arrival_time: departure_datetime + request_input.max_journey_duration,
             max_nb_legs: request_input.max_nb_of_legs,
             too_late_threshold: request_input.too_late_threshold,
+            real_time_level: request_input.real_time_level.clone(),
         };
 
         Ok(result)
@@ -244,7 +247,7 @@ where
     ) -> Option<(Data::Trip, Criteria)> {
         let waiting_time = &waiting_criteria.time;
         self.transit_data
-            .earliest_trip_to_board_at(waiting_time, mission, position)
+            .earliest_trip_to_board_at(waiting_time, mission, position, &self.real_time_level)
             .map(|(trip, arrival_time, load)| {
                 let new_criteria = Criteria {
                     time: arrival_time,
@@ -381,7 +384,12 @@ where
         let mission = &self.transit_data.mission_of(trip);
         let (new_trip, _, _) = self
             .transit_data
-            .latest_trip_that_debark_at(&debark_time, mission, debark_position)
+            .latest_trip_that_debark_at(
+                &debark_time,
+                mission,
+                debark_position,
+                &self.real_time_level,
+            )
             .ok_or_else(|| NoTrip(debark_time, mission.clone(), debark_position.clone()))?;
         *trip = new_trip;
         let board_time = self

--- a/src/request/depart_after.rs
+++ b/src/request/depart_after.rs
@@ -474,8 +474,8 @@ where
         }
     }
 
-    fn trips_of(&'outer self, mission: &Data::Mission) -> Data::TripsOfMission {
-        self.transit_data.trips_of(mission)
+    fn trips_of(&'outer self, mission: &Data::Mission, real_time_level : &RealTimeLevel) -> Data::TripsOfMission {
+        self.transit_data.trips_of(mission, real_time_level)
     }
 }
 

--- a/src/request/depart_after/basic_comparator.rs
+++ b/src/request/depart_after/basic_comparator.rs
@@ -34,11 +34,16 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use crate::{ engine::engine_interface::{
+use crate::{
+    engine::engine_interface::{
         BadRequest, Request as RequestTrait, RequestDebug, RequestIO, RequestInput, RequestIters,
         RequestTypes, RequestWithIters,
-    }, models::ModelRefs, 
-    transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes, RealTimeLevel}};
+    },
+    models::ModelRefs,
+    transit_data::data_interface::{
+        Data as DataTrait, DataIters, DataWithIters, RealTimeLevel, TransitTypes,
+    },
+};
 
 use super::{Arrival, Arrivals, Criteria, Departure, Departures, GenericDepartAfterRequest};
 
@@ -208,7 +213,11 @@ where
     }
 
     type TripsOfMission = Data::TripsOfMission;
-    fn trips_of(&'outer self, mission: &Self::Mission, real_time_level : &RealTimeLevel) -> Self::TripsOfMission {
+    fn trips_of(
+        &'outer self,
+        mission: &Self::Mission,
+        real_time_level: &RealTimeLevel,
+    ) -> Self::TripsOfMission {
         self.generic.trips_of(mission, real_time_level)
     }
 }

--- a/src/request/depart_after/basic_comparator.rs
+++ b/src/request/depart_after/basic_comparator.rs
@@ -34,16 +34,14 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use crate::{
-    engine::engine_interface::{
+use crate::{ engine::engine_interface::{
         BadRequest, Request as RequestTrait, RequestDebug, RequestIO, RequestInput, RequestIters,
         RequestTypes, RequestWithIters,
-    },
-    models::ModelRefs,
-    transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes},
-};
+    }, models::ModelRefs, 
+    transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes, RealTimeLevel}};
 
 use super::{Arrival, Arrivals, Criteria, Departure, Departures, GenericDepartAfterRequest};
+
 pub struct Request<'data, 'model, Data: DataTrait> {
     generic: GenericDepartAfterRequest<'data, 'model, Data>,
 }
@@ -210,8 +208,8 @@ where
     }
 
     type TripsOfMission = Data::TripsOfMission;
-    fn trips_of(&'outer self, mission: &Self::Mission) -> Self::TripsOfMission {
-        self.generic.trips_of(mission)
+    fn trips_of(&'outer self, mission: &Self::Mission, real_time_level : &RealTimeLevel) -> Self::TripsOfMission {
+        self.generic.trips_of(mission, real_time_level)
     }
 }
 

--- a/src/request/depart_after/loads_comparator.rs
+++ b/src/request/depart_after/loads_comparator.rs
@@ -34,10 +34,7 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use crate::{
-    models::ModelRefs,
-    transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes},
-};
+use crate::{RealTimeLevel, models::ModelRefs, transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes}};
 
 use crate::engine::engine_interface::{
     BadRequest, Request as RequestTrait, RequestDebug, RequestIO, RequestInput, RequestIters,
@@ -213,8 +210,8 @@ where
     }
 
     type TripsOfMission = Data::TripsOfMission;
-    fn trips_of(&'outer self, mission: &Self::Mission) -> Self::TripsOfMission {
-        self.generic.trips_of(mission)
+    fn trips_of(&'outer self, mission: &Self::Mission, real_time_level : &RealTimeLevel) -> Self::TripsOfMission {
+        self.generic.trips_of(mission, real_time_level)
     }
 }
 

--- a/src/request/depart_after/loads_comparator.rs
+++ b/src/request/depart_after/loads_comparator.rs
@@ -34,7 +34,11 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use crate::{RealTimeLevel, models::ModelRefs, transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes}};
+use crate::{
+    models::ModelRefs,
+    transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes},
+    RealTimeLevel,
+};
 
 use crate::engine::engine_interface::{
     BadRequest, Request as RequestTrait, RequestDebug, RequestIO, RequestInput, RequestIters,
@@ -210,7 +214,11 @@ where
     }
 
     type TripsOfMission = Data::TripsOfMission;
-    fn trips_of(&'outer self, mission: &Self::Mission, real_time_level : &RealTimeLevel) -> Self::TripsOfMission {
+    fn trips_of(
+        &'outer self,
+        mission: &Self::Mission,
+        real_time_level: &RealTimeLevel,
+    ) -> Self::TripsOfMission {
         self.generic.trips_of(mission, real_time_level)
     }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -72,7 +72,7 @@ pub struct SecondsSinceDatasetUTCStart {
 }
 
 /// Number of days since the first allowed day of the data
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct DaysSinceDatasetStart {
     pub(super) days: u16,
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -92,6 +92,7 @@ pub struct Calendar {
 pub struct PositiveDuration {
     pub(super) seconds: u32,
 }
+
 #[derive(Debug)]
 pub enum PositiveDurationError {
     ParseIntError(std::num::ParseIntError),
@@ -117,6 +118,7 @@ impl std::fmt::Display for PositiveDurationError {
         }
     }
 }
+
 impl std::str::FromStr for PositiveDuration {
     type Err = PositiveDurationError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/src/time.rs
+++ b/src/time.rs
@@ -39,6 +39,7 @@ use std::fmt::{Display, Formatter};
 
 mod calendar;
 pub mod days_patterns;
+pub mod days_map;
 pub mod timezones_patterns;
 pub use timezones_patterns::TimezonesPatterns;
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -38,8 +38,8 @@ use chrono::{FixedOffset, NaiveDate};
 use std::fmt::{Display, Formatter};
 
 mod calendar;
-pub mod days_patterns;
 pub mod days_map;
+pub mod days_patterns;
 pub mod timezones_patterns;
 pub use timezones_patterns::TimezonesPatterns;
 

--- a/src/time/days_map.rs
+++ b/src/time/days_map.rs
@@ -27,10 +27,7 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-
-
-use crate::time::{DaysSinceDatasetStart};
-
+use crate::time::DaysSinceDatasetStart;
 
 use super::days_patterns::{DaysPattern, DaysPatterns};
 
@@ -44,30 +41,21 @@ pub struct DaysMap<T> {
 
 impl<T> DaysMap<T> {
     pub fn new() -> Self {
-        Self {
-            data: Vec::new(),
-        }
+        Self { data: Vec::new() }
     }
 
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
 
-    pub fn get(
-        &self,
-        day: &DaysSinceDatasetStart,
-        days_patterns: &DaysPatterns,
-    ) -> Option<&T> 
-    {
-        self.data
-            .iter()
-            .find_map(|(days_pattern, value)| {
-                if days_patterns.is_allowed(days_pattern, day) {
-                    Some(value)
-                } else {
-                    None
-                }
-            })
+    pub fn get(&self, day: &DaysSinceDatasetStart, days_patterns: &DaysPatterns) -> Option<&T> {
+        self.data.iter().find_map(|(days_pattern, value)| {
+            if days_patterns.is_allowed(days_pattern, day) {
+                Some(value)
+            } else {
+                None
+            }
+        })
     }
 
     pub fn insert(
@@ -75,8 +63,9 @@ impl<T> DaysMap<T> {
         days_pattern_to_insert: &DaysPattern,
         value_to_insert: T,
         days_patterns: &mut DaysPatterns,
-    ) -> Result<(), InsertError> 
-    where T : Eq
+    ) -> Result<(), InsertError>
+    where
+        T: Eq,
     {
         // is there a day in days_pattern_to_insert that is already set somewhere ?
         for (days_pattern, _) in self.data.iter() {
@@ -105,8 +94,7 @@ impl<T> DaysMap<T> {
         } else {
             // if value_to_insert does not appears in the Vec,
             // let's push a new element to the Vec with it
-            self.data
-                .push((*days_pattern_to_insert, value_to_insert));
+            self.data.push((*days_pattern_to_insert, value_to_insert));
         }
 
         Ok(())
@@ -116,17 +104,20 @@ impl<T> DaysMap<T> {
         &mut self,
         day_to_remove: &DaysSinceDatasetStart,
         days_patterns: &mut DaysPatterns,
-    ) -> Result<T, RemoveError> 
-    where T : Clone
+    ) -> Result<T, RemoveError>
+    where
+        T: Clone,
     {
         // let's try to find the first element where day_to_remove is set.
         // Because of invariant 1., if such an element is found, we know that
         // day_to_remove is not set in any other element
-        let has_days_pattern = self.data.iter_mut().enumerate().find(
-            |(_idx, (days_pattern, _timetable))| {
-                days_patterns.is_allowed(days_pattern, day_to_remove)
-            },
-        );
+        let has_days_pattern =
+            self.data
+                .iter_mut()
+                .enumerate()
+                .find(|(_idx, (days_pattern, _timetable))| {
+                    days_patterns.is_allowed(days_pattern, day_to_remove)
+                });
 
         let (removed_timetable, has_idx_to_remove) = match has_days_pattern {
             None => {

--- a/src/time/days_map.rs
+++ b/src/time/days_map.rs
@@ -49,6 +49,10 @@ impl<T> DaysMap<T> {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
     pub fn get(
         &self,
         day: &DaysSinceDatasetStart,
@@ -76,9 +80,9 @@ impl<T> DaysMap<T> {
     {
         // is there a day in days_pattern_to_insert that is already set somewhere ?
         for (days_pattern, _) in self.data.iter() {
-            if let Some(_day) = days_patterns.have_common_day(days_pattern, days_pattern_to_insert)
-            {
-                return Err(InsertError::DayAlreadySet);
+            let common_days = days_patterns.common_days(days_pattern, days_pattern_to_insert);
+            if common_days.is_empty() {
+                return Err(InsertError::DaysAlreadySet(common_days));
             }
         }
 
@@ -152,7 +156,7 @@ impl<T> DaysMap<T> {
 
 #[derive(Debug)]
 pub enum InsertError {
-    DayAlreadySet,
+    DaysAlreadySet(Vec<DaysSinceDatasetStart>),
 }
 #[derive(Debug)]
 pub enum RemoveError {

--- a/src/time/days_map.rs
+++ b/src/time/days_map.rs
@@ -1,0 +1,160 @@
+// Copyright  (C) 2021, Kisio Digital and/or its affiliates. All rights reserved.
+//
+// This file is part of Navitia,
+// the software to build cool stuff with public transport.
+//
+// Hope you'll enjoy and contribute to this project,
+// powered by Kisio Digital (www.kisio.com).
+// Help us simplify mobility and open public transport:
+// a non ending quest to the responsive locomotion way of traveling!
+//
+// LICENCE: This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+// Stay tuned using
+// twitter @navitia
+// channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+// https://groups.google.com/d/forum/navitia
+// www.navitia.io
+
+
+
+use crate::time::{DaysSinceDatasetStart};
+
+
+use super::days_patterns::{DaysPattern, DaysPatterns};
+
+#[derive(Debug)]
+pub struct DaysMap<T> {
+    // invariants :
+    //  1. a day is set in at most one DaysPattern of the Vec
+    //  2. a T appears at most once in the vec
+    data: Vec<(DaysPattern, T)>,
+}
+
+impl<T> DaysMap<T> {
+    pub fn new() -> Self {
+        Self {
+            data: Vec::new(),
+        }
+    }
+
+    pub fn get(
+        &self,
+        day: &DaysSinceDatasetStart,
+        days_patterns: &DaysPatterns,
+    ) -> Option<&T> 
+    {
+        self.data
+            .iter()
+            .find_map(|(days_pattern, value)| {
+                if days_patterns.is_allowed(days_pattern, day) {
+                    Some(value)
+                } else {
+                    None
+                }
+            })
+    }
+
+    pub fn insert(
+        &mut self,
+        days_pattern_to_insert: &DaysPattern,
+        value_to_insert: T,
+        days_patterns: &mut DaysPatterns,
+    ) -> Result<(), InsertError> 
+    where T : Eq
+    {
+        // is there a day in days_pattern_to_insert that is already set somewhere ?
+        for (days_pattern, _) in self.data.iter() {
+            if let Some(_day) = days_patterns.have_common_day(days_pattern, days_pattern_to_insert)
+            {
+                return Err(InsertError::DayAlreadySet);
+            }
+        }
+
+        // We try to find the first element whose value is value_to_insert .
+        // Because of our invariant 2., if such an element is found we know that
+        // value_to_insert does not appears in any other element of the vec.
+        let has_days_pattern = self
+            .data
+            .iter_mut()
+            .find(|(_days_pattern, value)| *value == value_to_insert)
+            .map(|(days_pattern, _)| days_pattern); // we are just interested in the pattern
+
+        if let Some(old_days_pattern) = has_days_pattern {
+            // so now timetable_to_insert is valid on old_days_pattern and days_pattern_to_insert
+            // let's create a new days_pattern for that
+            let new_days_pattern =
+                days_patterns.get_union(*old_days_pattern, *days_pattern_to_insert);
+
+            *old_days_pattern = new_days_pattern;
+        } else {
+            // if value_to_insert does not appears in the Vec,
+            // let's push a new element to the Vec with it
+            self.data
+                .push((*days_pattern_to_insert, value_to_insert));
+        }
+
+        Ok(())
+    }
+
+    pub fn remove(
+        &mut self,
+        day_to_remove: &DaysSinceDatasetStart,
+        days_patterns: &mut DaysPatterns,
+    ) -> Result<T, RemoveError> 
+    where T : Clone
+    {
+        // let's try to find the first element where day_to_remove is set.
+        // Because of invariant 1., if such an element is found, we know that
+        // day_to_remove is not set in any other element
+        let has_days_pattern = self.data.iter_mut().enumerate().find(
+            |(_idx, (days_pattern, _timetable))| {
+                days_patterns.is_allowed(days_pattern, day_to_remove)
+            },
+        );
+
+        let (removed_timetable, has_idx_to_remove) = match has_days_pattern {
+            None => {
+                return Err(RemoveError::DayNotSet);
+            }
+            Some((idx, (old_days_pattern, value))) => {
+                let new_days_pattern = days_patterns
+                    .get_pattern_without_day(*old_days_pattern, day_to_remove)
+                    .ok_or(RemoveError::DayNotSet)?;
+
+                if days_patterns.is_empty_pattern(&new_days_pattern) {
+                    (value.clone(), Some(idx))
+                } else {
+                    *old_days_pattern = new_days_pattern;
+                    (value.clone(), None)
+                }
+            }
+        };
+
+        if let Some(idx) = has_idx_to_remove {
+            self.data.swap_remove(idx);
+        }
+
+        Ok(removed_timetable)
+    }
+}
+
+#[derive(Debug)]
+pub enum InsertError {
+    DayAlreadySet,
+}
+#[derive(Debug)]
+pub enum RemoveError {
+    DayNotSet,
+}

--- a/src/time/days_patterns.rs
+++ b/src/time/days_patterns.rs
@@ -38,6 +38,7 @@ use std::{iter::Enumerate, ops::Not};
 
 use crate::time::{Calendar, DaysSinceDatasetStart};
 use chrono::NaiveDate;
+use tracing::trace;
 
 #[derive(Debug)]
 pub struct DaysPatterns {
@@ -188,25 +189,24 @@ impl DaysPatterns {
         Some(result)
     }
 
-    // pub fn get_pattern_with_additional_day(
-    //     &mut self,
-    //     original_pattern: DaysPattern,
-    //     day_to_add: &DaysSinceDatasetStart,
-    // ) -> Result<DaysPattern, ()> {
-    //     if self.is_allowed(&original_pattern, day_to_add) {
-    //         return Err(());
-    //     }
-    //     let original_allowed_dates = &self.days_patterns[original_pattern.idx].allowed_dates;
+    pub fn get_pattern_with_additional_day(
+        &mut self,
+        original_pattern: DaysPattern,
+        day_to_add: &DaysSinceDatasetStart,
+    ) -> DaysPattern {
+        if self.is_allowed(&original_pattern, day_to_add) {
+            trace!("Adding a day already set to a pattern");
+            return original_pattern;
+        }
+        let original_allowed_dates = &self.days_patterns[original_pattern.idx].allowed_dates;
 
-    //     // let's put the actual pattern of allowed days into self.buffer
-    //     debug_assert!(original_allowed_dates.len() == self.buffer.len());
-    //     self.buffer.copy_from_slice(original_allowed_dates);
-    //     self.buffer[day_to_add.days as usize] = true;
+        // let's put the actual pattern of allowed days into self.buffer
+        debug_assert!(original_allowed_dates.len() == self.buffer.len());
+        self.buffer.copy_from_slice(original_allowed_dates);
+        self.buffer[day_to_add.days as usize] = true;
 
-    //     let result = self.get_or_insert_from_buffer();
-
-    //     Ok(result)
-    // }
+        self.get_or_insert_from_buffer()
+    }
 
     pub fn get_intersection(
         &mut self,

--- a/src/time/days_patterns.rs
+++ b/src/time/days_patterns.rs
@@ -57,10 +57,17 @@ pub struct DaysPattern {
 
 impl DaysPatterns {
     pub fn new(nb_of_days: usize) -> Self {
-        Self {
+        let mut result = Self {
             days_patterns: Vec::new(),
             buffer: vec![false; nb_of_days],
-        }
+        };
+        let empty_pattern = result.get_from_days(std::iter::empty());
+        assert!(empty_pattern.idx == 0);
+        result
+    }
+
+    pub fn empty_pattern(&self) -> DaysPattern {
+        DaysPattern{idx : 0}
     }
 
     pub fn is_allowed(&self, days_pattern: &DaysPattern, day: &DaysSinceDatasetStart) -> bool {
@@ -155,9 +162,10 @@ impl DaysPatterns {
     }
 
     pub fn is_empty_pattern(&self, days_pattern: &DaysPattern) -> bool {
-        let allowed_dates = &self.days_patterns[days_pattern.idx].allowed_dates;
-        let has_a_day_set = allowed_dates.iter().any(|day_allowed| *day_allowed);
-        has_a_day_set.not()
+        days_pattern.idx == 0
+        // let allowed_dates = &self.days_patterns[days_pattern.idx].allowed_dates;
+        // let has_a_day_set = allowed_dates.iter().any(|day_allowed| *day_allowed);
+        // has_a_day_set.not()
     }
 
     pub fn get_pattern_without_day(
@@ -242,15 +250,13 @@ impl DaysPatterns {
         &self,
         first_pattern: &DaysPattern,
         second_pattern: &DaysPattern,
-        calendar: &Calendar,
     ) -> Vec<DaysSinceDatasetStart> {
         let first_data = &self.days_patterns[first_pattern.idx].allowed_dates;
         let second_data = &self.days_patterns[second_pattern.idx].allowed_dates;
-        let days = calendar.days();
         let mut result = Vec::new();
-        for (day, (first, second)) in days.zip(first_data.iter().zip(second_data.iter())) {
+        for (day_idx, (first, second)) in first_data.iter().zip(second_data.iter()).enumerate() {
             if *first && *second {
-                result.push(day);
+                result.push(DaysSinceDatasetStart { days : day_idx as u16});
             }
         }
         result

--- a/src/time/days_patterns.rs
+++ b/src/time/days_patterns.rs
@@ -119,6 +119,21 @@ impl DaysPatterns {
         self.get_or_insert_from_buffer()
     }
 
+    pub fn get_from_days<Days>(&mut self, days: Days, calendar: &Calendar) -> DaysPattern
+    where
+        Days: Iterator<Item = DaysSinceDatasetStart>,
+    {
+        // set all elements of the buffer to false
+        self.buffer.fill(false);
+
+        for day in days {
+            let offset = day.days;
+            self.buffer[offset as usize] = true;
+        }
+
+        self.get_or_insert_from_buffer()
+    }
+
     pub fn make_dates(&self, days_pattern: &DaysPattern, calendar: &Calendar) -> Vec<NaiveDate> {
         let mut result = Vec::new();
         for day in calendar.days() {
@@ -260,6 +275,7 @@ impl DaysPatterns {
     }
 }
 
+#[derive(Clone)]
 pub struct DaysInPatternIter<'pattern> {
     allowed_dates: Enumerate<std::slice::Iter<'pattern, bool>>,
 }

--- a/src/time/days_patterns.rs
+++ b/src/time/days_patterns.rs
@@ -67,7 +67,7 @@ impl DaysPatterns {
     }
 
     pub fn empty_pattern(&self) -> DaysPattern {
-        DaysPattern{idx : 0}
+        DaysPattern { idx: 0 }
     }
 
     pub fn is_allowed(&self, days_pattern: &DaysPattern, day: &DaysSinceDatasetStart) -> bool {
@@ -256,7 +256,9 @@ impl DaysPatterns {
         let mut result = Vec::new();
         for (day_idx, (first, second)) in first_data.iter().zip(second_data.iter()).enumerate() {
             if *first && *second {
-                result.push(DaysSinceDatasetStart { days : day_idx as u16});
+                result.push(DaysSinceDatasetStart {
+                    days: day_idx as u16,
+                });
             }
         }
         result

--- a/src/time/days_patterns.rs
+++ b/src/time/days_patterns.rs
@@ -119,7 +119,7 @@ impl DaysPatterns {
         self.get_or_insert_from_buffer()
     }
 
-    pub fn get_from_days<Days>(&mut self, days: Days, calendar: &Calendar) -> DaysPattern
+    pub fn get_from_days<Days>(&mut self, days: Days, _calendar: &Calendar) -> DaysPattern
     where
         Days: Iterator<Item = DaysSinceDatasetStart>,
     {

--- a/src/time/days_patterns.rs
+++ b/src/time/days_patterns.rs
@@ -119,7 +119,7 @@ impl DaysPatterns {
         self.get_or_insert_from_buffer()
     }
 
-    pub fn get_from_days<Days>(&mut self, days: Days, _calendar: &Calendar) -> DaysPattern
+    pub fn get_from_days<Days>(&mut self, days: Days) -> DaysPattern
     where
         Days: Iterator<Item = DaysSinceDatasetStart>,
     {

--- a/src/timetables.rs
+++ b/src/timetables.rs
@@ -202,7 +202,7 @@ pub trait Timetables: Types {
         valid_dates: Dates,
         timezone: &chrono_tz::Tz,
         vehicle_journey_idx: &VehicleJourneyIdx,
-        real_time_validity: &RealTimeValidity,
+        real_time_level: &RealTimeLevel,
     ) -> (Vec<Self::Mission>, Vec<InsertionError>)
     where
         Stops: Iterator<Item = Stop> + ExactSizeIterator + Clone,
@@ -211,27 +211,47 @@ pub trait Timetables: Types {
         BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
         DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone;
 
+
+    fn modify<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
+            &mut self,
+            stops: Stops,
+            flows: Flows,
+            board_times: BoardTimes,
+            debark_times: DebarkTimes,
+            loads_data: &LoadsData,
+            valid_dates: Dates,
+            timezone: &chrono_tz::Tz,
+            vehicle_journey_idx: &VehicleJourneyIdx,
+        ) -> (Vec<Self::Mission>, Vec<InsertionError>)
+        where
+            Stops: Iterator<Item = Stop> + ExactSizeIterator + Clone,
+            Flows: Iterator<Item = FlowDirection> + ExactSizeIterator + Clone,
+            Dates: Iterator<Item = &'date chrono::NaiveDate> + Clone,
+            BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
+            DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone;
+
     fn remove(
         &mut self,
         date: &chrono::NaiveDate,
         vehicle_journey_idx: &VehicleJourneyIdx,
-        real_time_validity: &RealTimeValidity,
     ) -> Result<(), RemovalError>;
+
 }
 
 #[derive(Clone, Debug)]
 pub enum InsertionError {
     Times(VehicleJourneyIdx, VehicleTimesError, Vec<NaiveDate>),
-    VehicleJourneyAlreadyExistsOnDate(NaiveDate, VehicleJourneyIdx, RealTimeValidity),
+    VehicleJourneyAlreadyExistsOnDate(NaiveDate, VehicleJourneyIdx, RealTimeLevel),
     InvalidDate(NaiveDate, VehicleJourneyIdx),
 }
 
 #[derive(Clone, Debug)]
 pub enum RemovalError {
-    UnknownDate(NaiveDate, VehicleJourneyIdx, RealTimeValidity),
-    UnknownVehicleJourney(VehicleJourneyIdx, RealTimeValidity),
-    DateInvalidForVehicleJourney(NaiveDate, VehicleJourneyIdx, RealTimeValidity),
+    UnknownDate(NaiveDate, VehicleJourneyIdx),
+    UnknownVehicleJourney(VehicleJourneyIdx),
+    DateInvalidForVehicleJourney(NaiveDate, VehicleJourneyIdx),
 }
+
 
 pub trait TimetablesIter<'a>: Types {
     type Positions: Iterator<Item = Self::Position>;

--- a/src/timetables.rs
+++ b/src/timetables.rs
@@ -34,7 +34,6 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-
 mod day_to_timetable;
 pub(crate) mod generic_timetables;
 mod iters;
@@ -62,7 +61,6 @@ use chrono::NaiveDate;
 use std::fmt::Debug;
 
 use self::generic_timetables::VehicleTimesError;
-
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
 pub enum FlowDirection {
@@ -177,7 +175,6 @@ pub trait Timetables: Types {
     where
         Filter: Fn(&VehicleJourneyIdx) -> bool;
 
-
     fn insert_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
         &mut self,
         stops: Stops,
@@ -188,7 +185,7 @@ pub trait Timetables: Types {
         valid_dates: Dates,
         timezone: &chrono_tz::Tz,
         vehicle_journey_idx: &VehicleJourneyIdx,
-        real_time_level : &RealTimeLevel,
+        real_time_level: &RealTimeLevel,
     ) -> Result<Vec<Self::Mission>, InsertionError>
     where
         Stops: Iterator<Item = Stop> + ExactSizeIterator + Clone,
@@ -197,31 +194,29 @@ pub trait Timetables: Types {
         BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
         DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone;
 
-
     fn modify_real_time_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
-            &mut self,
-            stops: Stops,
-            flows: Flows,
-            board_times: BoardTimes,
-            debark_times: DebarkTimes,
-            loads_data: &LoadsData,
-            valid_dates: Dates,
-            timezone: &chrono_tz::Tz,
-            vehicle_journey_idx: &VehicleJourneyIdx,
-        ) -> Result<Vec<Self::Mission>, ModifyError>
-        where
-            Stops: Iterator<Item = Stop> + ExactSizeIterator + Clone,
-            Flows: Iterator<Item = FlowDirection> + ExactSizeIterator + Clone,
-            Dates: Iterator<Item = &'date chrono::NaiveDate> + Clone,
-            BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
-            DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone;
+        &mut self,
+        stops: Stops,
+        flows: Flows,
+        board_times: BoardTimes,
+        debark_times: DebarkTimes,
+        loads_data: &LoadsData,
+        valid_dates: Dates,
+        timezone: &chrono_tz::Tz,
+        vehicle_journey_idx: &VehicleJourneyIdx,
+    ) -> Result<Vec<Self::Mission>, ModifyError>
+    where
+        Stops: Iterator<Item = Stop> + ExactSizeIterator + Clone,
+        Flows: Iterator<Item = FlowDirection> + ExactSizeIterator + Clone,
+        Dates: Iterator<Item = &'date chrono::NaiveDate> + Clone,
+        BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
+        DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone;
 
     fn remove_real_time_vehicle(
         &mut self,
         date: &chrono::NaiveDate,
         vehicle_journey_idx: &VehicleJourneyIdx,
     ) -> Result<(), RemovalError>;
-
 }
 
 #[derive(Clone, Debug)]
@@ -247,13 +242,12 @@ pub enum ModifyError {
     Times(VehicleJourneyIdx, VehicleTimesError, Vec<NaiveDate>),
 }
 
-
 pub trait TimetablesIter<'a>: Types {
     type Positions: Iterator<Item = Self::Position>;
     fn positions(&'a self, mission: &Self::Mission) -> Self::Positions;
 
     type Trips: Iterator<Item = Self::Trip>;
-    fn trips_of(&'a self, mission: &Self::Mission, real_time_level : &RealTimeLevel) -> Self::Trips;
+    fn trips_of(&'a self, mission: &Self::Mission, real_time_level: &RealTimeLevel) -> Self::Trips;
 
     type Missions: Iterator<Item = Self::Mission>;
     fn missions(&'a self) -> Self::Missions;

--- a/src/timetables.rs
+++ b/src/timetables.rs
@@ -39,7 +39,7 @@ pub(crate) mod generic_timetables;
 mod iters;
 
 // mod daily;
-// mod periodic;
+mod periodic;
 mod periodic_split_vj_by_tz;
 
 // pub use daily::DailyTimetables;

--- a/src/timetables.rs
+++ b/src/timetables.rs
@@ -218,7 +218,7 @@ pub trait Timetables: Types {
 #[derive(Clone, Debug)]
 pub enum InsertionError {
     Times(VehicleJourneyIdx, VehicleTimesError, Vec<NaiveDate>),
-    VehicleJourneyAlreadyExistsOnDate(NaiveDate, VehicleJourneyIdx),
+    VehicleJourneyAlreadyExistsOnDate(NaiveDate, VehicleJourneyIdx, RealTimeValidity),
     InvalidDate(NaiveDate, VehicleJourneyIdx),
 }
 

--- a/src/timetables.rs
+++ b/src/timetables.rs
@@ -42,8 +42,8 @@ mod daily;
 mod periodic;
 mod periodic_split_vj_by_tz;
 
-// pub use daily::DailyTimetables;
-// pub use periodic::PeriodicTimetables;
+pub use daily::DailyTimetables;
+pub use periodic::PeriodicTimetables;
 pub use periodic_split_vj_by_tz::PeriodicSplitVjByTzTimetables;
 
 use std::{collections::HashMap, hash::Hash};

--- a/src/timetables.rs
+++ b/src/timetables.rs
@@ -61,7 +61,7 @@ use std::fmt::Debug;
 
 use self::generic_timetables::VehicleTimesError;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RealTimeValidity {
     BaseOnly,
     RealTimeOnly,
@@ -203,7 +203,7 @@ pub trait Timetables: Types {
     where
         Stops: Iterator<Item = Stop> + ExactSizeIterator + Clone,
         Flows: Iterator<Item = FlowDirection> + ExactSizeIterator + Clone,
-        Dates: Iterator<Item = &'date chrono::NaiveDate>,
+        Dates: Iterator<Item = &'date chrono::NaiveDate> + Clone,
         BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
         DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone;
 
@@ -211,7 +211,7 @@ pub trait Timetables: Types {
         &mut self,
         date: &chrono::NaiveDate,
         vehicle_journey_idx: &VehicleJourneyIdx,
-        real_time_level: &RealTimeLevel,
+        real_time_validity: &RealTimeValidity,
     ) -> Result<(), RemovalError>;
 }
 
@@ -224,9 +224,9 @@ pub enum InsertionError {
 
 #[derive(Clone, Debug)]
 pub enum RemovalError {
-    UnknownDate(NaiveDate, VehicleJourneyIdx),
-    UnknownVehicleJourney(VehicleJourneyIdx),
-    DateInvalidForVehicleJourney(NaiveDate, VehicleJourneyIdx),
+    UnknownDate(NaiveDate, VehicleJourneyIdx, RealTimeValidity),
+    UnknownVehicleJourney(VehicleJourneyIdx, RealTimeValidity),
+    DateInvalidForVehicleJourney(NaiveDate, VehicleJourneyIdx, RealTimeValidity),
 }
 
 pub trait TimetablesIter<'a>: Types {

--- a/src/timetables.rs
+++ b/src/timetables.rs
@@ -37,12 +37,12 @@
 mod day_to_timetable;
 pub(crate) mod generic_timetables;
 mod iters;
-// mod daily;
-// mod periodic;
+mod daily;
+mod periodic;
 mod periodic_split_vj_by_tz;
 
-// pub use daily::DailyTimetables;
-// pub use periodic::PeriodicTimetables;
+pub use daily::DailyTimetables;
+pub use periodic::PeriodicTimetables;
 pub use periodic_split_vj_by_tz::PeriodicSplitVjByTzTimetables;
 
 use std::hash::Hash;

--- a/src/timetables.rs
+++ b/src/timetables.rs
@@ -70,12 +70,12 @@ pub enum RealTimeValidity {
 
 impl RealTimeValidity {
     pub fn is_valid_for(&self, real_time_level: &RealTimeLevel) -> bool {
-        match (self, real_time_level) {
-            (RealTimeValidity::BaseAndRealTime, _) => true,
-            (RealTimeValidity::BaseOnly, RealTimeLevel::Base) => true,
-            (RealTimeValidity::RealTimeOnly, RealTimeLevel::RealTime) => true,
-            _ => false,
-        }
+        matches!(
+            (self, real_time_level),
+            (RealTimeValidity::BaseAndRealTime, _)
+                | (RealTimeValidity::BaseOnly, RealTimeLevel::Base)
+                | (RealTimeValidity::RealTimeOnly, RealTimeLevel::RealTime)
+        )
     }
 }
 

--- a/src/timetables.rs
+++ b/src/timetables.rs
@@ -34,15 +34,17 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-mod daily;
+
 mod day_to_timetable;
 pub(crate) mod generic_timetables;
 mod iters;
-mod periodic;
+
+// mod daily;
+// mod periodic;
 mod periodic_split_vj_by_tz;
 
-pub use daily::DailyTimetables;
-pub use periodic::PeriodicTimetables;
+// pub use daily::DailyTimetables;
+// pub use periodic::PeriodicTimetables;
 pub use periodic_split_vj_by_tz::PeriodicSplitVjByTzTimetables;
 
 use std::hash::Hash;
@@ -242,6 +244,7 @@ pub enum ModifyError {
     UnknownDate(NaiveDate, VehicleJourneyIdx),
     UnknownVehicleJourney(VehicleJourneyIdx),
     DateInvalidForVehicleJourney(NaiveDate, VehicleJourneyIdx),
+    Times(VehicleJourneyIdx, VehicleTimesError, Vec<NaiveDate>),
 }
 
 

--- a/src/timetables.rs
+++ b/src/timetables.rs
@@ -73,7 +73,7 @@ pub type StopFlows = Vec<(Stop, FlowDirection)>;
 
 pub trait Types {
     type Mission: Debug + Clone + Hash + Eq;
-    type Position: Debug + Clone;
+    type Position: Debug + Clone + PartialEq + Eq;
     type Trip: Debug + Clone;
 }
 
@@ -175,25 +175,8 @@ pub trait Timetables: Types {
     where
         Filter: Fn(&VehicleJourneyIdx) -> bool;
 
-    fn insert_base_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
-        &mut self,
-        stops: Stops,
-        flows: Flows,
-        board_times: BoardTimes,
-        debark_times: DebarkTimes,
-        loads_data: &LoadsData,
-        valid_dates: Dates,
-        timezone: &chrono_tz::Tz,
-        vehicle_journey_idx: &VehicleJourneyIdx,
-    ) -> Result<Vec<Self::Mission>, InsertionError>
-    where
-        Stops: Iterator<Item = Stop> + ExactSizeIterator + Clone,
-        Flows: Iterator<Item = FlowDirection> + ExactSizeIterator + Clone,
-        Dates: Iterator<Item = &'date chrono::NaiveDate> + Clone,
-        BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
-        DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone;
 
-    fn insert_real_time_only_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
+    fn insert_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
         &mut self,
         stops: Stops,
         flows: Flows,
@@ -203,6 +186,7 @@ pub trait Timetables: Types {
         valid_dates: Dates,
         timezone: &chrono_tz::Tz,
         vehicle_journey_idx: &VehicleJourneyIdx,
+        real_time_level : &RealTimeLevel,
     ) -> Result<Vec<Self::Mission>, InsertionError>
     where
         Stops: Iterator<Item = Stop> + ExactSizeIterator + Clone,

--- a/src/timetables.rs
+++ b/src/timetables.rs
@@ -34,10 +34,10 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
+mod daily;
 mod day_to_timetable;
 pub(crate) mod generic_timetables;
 mod iters;
-mod daily;
 mod periodic;
 mod periodic_split_vj_by_tz;
 

--- a/src/timetables.rs
+++ b/src/timetables.rs
@@ -38,7 +38,7 @@ pub mod day_to_timetable;
 pub(crate) mod generic_timetables;
 mod iters;
 
-// mod daily;
+mod daily;
 mod periodic;
 mod periodic_split_vj_by_tz;
 
@@ -82,7 +82,7 @@ pub trait Types {
 }
 
 pub trait Timetables: Types {
-    fn new(first_date: NaiveDate, last_date: NaiveDate) -> Self;
+    fn new() -> Self;
 
     fn nb_of_missions(&self) -> usize;
     fn mission_id(&self, mission: &Self::Mission) -> usize;

--- a/src/timetables.rs
+++ b/src/timetables.rs
@@ -69,7 +69,7 @@ pub enum RealTimeValidity {
 }
 
 impl RealTimeValidity {
-    pub fn is_valid_for(&self, real_time_level: RealTimeLevel) -> bool {
+    pub fn is_valid_for(&self, real_time_level: &RealTimeLevel) -> bool {
         match (self, real_time_level) {
             (RealTimeValidity::BaseAndRealTime, _) => true,
             (RealTimeValidity::BaseOnly, RealTimeLevel::Base) => true,
@@ -159,6 +159,7 @@ pub trait Timetables: Types {
         waiting_time: &SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>;
 
     fn earliest_filtered_trip_to_board_at<Filter>(
@@ -166,6 +167,7 @@ pub trait Timetables: Types {
         waiting_time: &SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
         filter: Filter,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>
     where
@@ -176,6 +178,7 @@ pub trait Timetables: Types {
         time: &SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>;
 
     fn latest_filtered_trip_that_debark_at<Filter>(
@@ -183,6 +186,7 @@ pub trait Timetables: Types {
         time: &SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
         filter: Filter,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>
     where

--- a/src/timetables/daily.rs
+++ b/src/timetables/daily.rs
@@ -202,8 +202,12 @@ impl TimetablesTrait for DailyTimetables {
     where
         Filter: Fn(&VehicleJourneyIdx) -> bool,
     {
-        let vehicle_data_filter =
-            |vehicle_data: &VehicleData| filter(&vehicle_data.vehicle_journey_idx);
+        let vehicle_data_filter = |vehicle_data: &VehicleData| {
+            filter(&vehicle_data.vehicle_journey_idx)
+                && vehicle_data
+                    .real_time_validity
+                    .is_valid_for(real_time_level)
+        };
         self.timetables
             .earliest_filtered_vehicle_to_board(
                 waiting_time,
@@ -239,8 +243,12 @@ impl TimetablesTrait for DailyTimetables {
     where
         Filter: Fn(&VehicleJourneyIdx) -> bool,
     {
-        let vehicle_data_filter =
-            |vehicle_data: &VehicleData| filter(&vehicle_data.vehicle_journey_idx);
+        let vehicle_data_filter = |vehicle_data: &VehicleData| {
+            filter(&vehicle_data.vehicle_journey_idx)
+                && vehicle_data
+                    .real_time_validity
+                    .is_valid_for(real_time_level)
+        };
         self.timetables
             .latest_filtered_vehicle_that_debark(time, mission, position, vehicle_data_filter)
             .map(|(vehicle, time, load)| {
@@ -401,7 +409,7 @@ impl TimetablesTrait for DailyTimetables {
                     real_time_validity.clone(),
                 ),
                 Unknown::DayForVehicleJourney => RemovalError::DateInvalidForVehicleJourney(
-                    date.clone(),
+                    *date,
                     vehicle_journey_idx.clone(),
                     real_time_validity.clone(),
                 ),

--- a/src/timetables/daily.rs
+++ b/src/timetables/daily.rs
@@ -55,7 +55,6 @@ use tracing::log::error;
 
 pub type Time = SecondsSinceDatasetUTCStart;
 
-
 pub struct DailyTimetables {
     timetables: Timetables<Time, Load, (), VehicleData>,
     calendar: Calendar,

--- a/src/timetables/daily.rs
+++ b/src/timetables/daily.rs
@@ -400,39 +400,6 @@ impl TimetablesTrait for DailyTimetables {
             }
         }
     }
-    fn remove_all_vehicle_on_day(&mut self, date: &chrono::NaiveDate) {
-        let day = {
-            let has_day = self.calendar.date_to_days_since_start(date);
-            if let Some(day) = has_day {
-                day
-            } else {
-                warn!(
-                    "Asked to remove all vehicle on day {}, which is invalid for the calendar. \
-                            Allowed dates are between {} and {}",
-                    date,
-                    self.calendar.first_date(),
-                    self.calendar.last_date(),
-                );
-                return;
-            }
-        };
-        let mut vehicle_journeys_to_remove = Vec::new();
-        for (vehicle_journey_idx, day_to_timetable) in self.vehicle_journey_to_timetables.iter() {
-            if day_to_timetable.contains_day(&day, &self.days_patterns) {
-                vehicle_journeys_to_remove.push(vehicle_journey_idx.clone());
-            }
-        }
-        for vehicle_journey_idx in vehicle_journeys_to_remove {
-            let removal_result = self.remove(date, &vehicle_journey_idx);
-            if let Err(removal_error) = removal_result {
-                warn!(
-                    "Removal error occured while removing all vehicles on day {}. \
-                    {:?}",
-                    date, removal_error
-                )
-            }
-        }
-    }
 }
 
 impl<'a> TimetablesIter<'a> for DailyTimetables {

--- a/src/timetables/daily.rs
+++ b/src/timetables/daily.rs
@@ -374,7 +374,7 @@ impl TimetablesTrait for DailyTimetables {
                 Ok(mission) => {
                     let pattern = result
                         .entry(mission)
-                        .or_insert(days_patterns.empty_pattern());
+                        .or_insert_with(|| days_patterns.empty_pattern());
                     *pattern = days_patterns.get_pattern_with_additional_day(*pattern, &day);
                 }
                 Err(times_error) => {
@@ -400,7 +400,7 @@ impl TimetablesTrait for DailyTimetables {
         _calendar: &Calendar,
         _days_patterns: &mut DaysPatterns,
     ) {
-        let timetable_data = self.timetables.timetable_data_mut(&mission);
+        let timetable_data = self.timetables.timetable_data_mut(mission);
 
         let nb_vehicle_updated = timetable_data.update_vehicles_data(|vehicle_data| {
             let is_valid = match real_time_level {

--- a/src/timetables/daily.rs
+++ b/src/timetables/daily.rs
@@ -55,7 +55,7 @@ use tracing::log::error;
 
 pub type Time = SecondsSinceDatasetUTCStart;
 
-#[derive(Debug)]
+
 pub struct DailyTimetables {
     timetables: Timetables<Time, Load, (), VehicleData>,
     calendar: Calendar,

--- a/src/timetables/day_to_timetable.rs
+++ b/src/timetables/day_to_timetable.rs
@@ -160,31 +160,6 @@ impl VehicleJourneyToTimetable {
             .map_err(|_| Unknown::DayForVehicleJourney)
     }
 
-    pub fn update_real_time_vehicle(
-        &mut self,
-        vehicle_journey_idx: &VehicleJourneyIdx,
-        day: &DaysSinceDatasetStart,
-        timetable_to_insert: &Timetable,
-        days_patterns: &mut DaysPatterns,
-    ) -> Result<(), Unknown> {
-        let day_to_timetable = self
-            .data
-            .get_mut(vehicle_journey_idx)
-            .ok_or(Unknown::VehicleJourneyIdx)?;
-        day_to_timetable
-            .real_time
-            .remove(day, days_patterns)
-            .map_err(|_| Unknown::DayForVehicleJourney)?;
-        let days_pattern_to_insert = days_patterns.get_for_day(day);
-        day_to_timetable.real_time.insert(
-            &days_pattern_to_insert,
-            timetable_to_insert.clone(),
-            days_patterns,
-        );
-
-        Ok(())
-    }
-
     pub fn base_vehicle_exists(&self, vehicle_journey_idx: &VehicleJourneyIdx) -> bool {
         let has_day_to_timetable = self.data.get(vehicle_journey_idx);
         if let Some(day_to_timetable) = has_day_to_timetable {
@@ -207,31 +182,7 @@ impl VehicleJourneyToTimetable {
             false
         }
     }
-
-    pub fn get_timetable(
-        &self,
-        vehicle_journey_idx: &VehicleJourneyIdx,
-        day: &DaysSinceDatasetStart,
-        days_patterns: &DaysPatterns,
-        real_time_level: &RealTimeLevel,
-    ) -> Result<&Timetable, Unknown> {
-        let day_to_timetable = self
-            .data
-            .get(vehicle_journey_idx)
-            .ok_or_else(|| Unknown::VehicleJourneyIdx)?;
-        let data = match real_time_level {
-            RealTimeLevel::Base => &day_to_timetable.real_time,
-            RealTimeLevel::RealTime => &day_to_timetable.base,
-        };
-        data.get(day, days_patterns)
-            .ok_or_else(|| Unknown::DayForVehicleJourney)
-    }
 }
-
-pub enum RemovalError {
-    DayNotSet(VehicleJourneyIdx, DaysSinceDatasetStart),
-}
-
 #[derive(Debug)]
 pub enum InsertionError {
     DaysAlreadySet(VehicleJourneyIdx, RealTimeLevel, Vec<DaysSinceDatasetStart>),

--- a/src/timetables/day_to_timetable.rs
+++ b/src/timetables/day_to_timetable.rs
@@ -120,6 +120,7 @@ impl VehicleJourneyToTimetable {
 
 }
 
+#[derive(Debug)]
 pub enum Unknown {
     VehicleJourneyIdx,
     DayForVehicleJourney,

--- a/src/timetables/day_to_timetable.rs
+++ b/src/timetables/day_to_timetable.rs
@@ -46,18 +46,16 @@ use crate::{
     RealTimeLevel,
 };
 
-use super::generic_timetables::Timetable;
-
-pub struct VehicleJourneyToTimetable {
-    data: HashMap<VehicleJourneyIdx, DayToTimetable>,
+pub struct VehicleJourneyToTimetable<Timetable> {
+    data: HashMap<VehicleJourneyIdx, DayToTimetable<Timetable>>,
 }
 
-struct DayToTimetable {
+struct DayToTimetable<Timetable> {
     base: DaysMap<Timetable>,
     real_time: DaysMap<Timetable>,
 }
 
-impl DayToTimetable {
+impl<Timetable> DayToTimetable<Timetable> {
     fn new() -> Self {
         Self {
             base: DaysMap::new(),
@@ -66,7 +64,10 @@ impl DayToTimetable {
     }
 }
 
-impl VehicleJourneyToTimetable {
+impl<Timetable> VehicleJourneyToTimetable<Timetable>
+where
+    Timetable: PartialEq + Eq + Clone,
+{
     pub fn new() -> Self {
         Self {
             data: HashMap::new(),

--- a/src/timetables/day_to_timetable.rs
+++ b/src/timetables/day_to_timetable.rs
@@ -94,7 +94,7 @@ impl VehicleJourneyToTimetable {
             RealTimeValidity::RealTimeOnly => &mut self.real_time_only,
         };
         data.entry(vehicle_journey_idx.clone())
-            .or_insert_with(|| DayToTimetable::new())
+            .or_insert_with(DayToTimetable::new)
             .insert_days_pattern(days_pattern_to_insert, timetable_to_insert, days_patterns)
     }
 

--- a/src/timetables/day_to_timetable.rs
+++ b/src/timetables/day_to_timetable.rs
@@ -84,7 +84,7 @@ where
         let day_to_timetable = self
             .data
             .entry(vehicle_journey_idx.clone())
-            .or_insert_with(|| DayToTimetable::new());
+            .or_insert_with(DayToTimetable::new);
 
         let base_insert_result = day_to_timetable.base.insert(
             days_pattern_to_insert,
@@ -126,7 +126,7 @@ where
         let day_to_timetable = self
             .data
             .entry(vehicle_journey_idx.clone())
-            .or_insert_with(|| DayToTimetable::new());
+            .or_insert_with(DayToTimetable::new);
 
         let real_time_insert_result = day_to_timetable.real_time.insert(
             days_pattern_to_insert,

--- a/src/timetables/day_to_timetable.rs
+++ b/src/timetables/day_to_timetable.rs
@@ -54,7 +54,7 @@ pub struct VehicleJourneyToTimetable {
 }
 
 impl VehicleJourneyToTimetable {
-    pub fn new() -> Self { 
+    pub fn new() -> Self {
         Self {
             base_and_real_time: HashMap::new(),
             base_only: HashMap::new(),
@@ -66,32 +66,32 @@ impl VehicleJourneyToTimetable {
         &self,
         vehicle_journey_idx: &VehicleJourneyIdx,
         day: &DaysSinceDatasetStart,
-        real_time_validity : &RealTimeValidity,
+        real_time_validity: &RealTimeValidity,
         days_patterns: &DaysPatterns,
     ) -> Result<Timetable, Unknown> {
         let data = match *real_time_validity {
-            RealTimeValidity::BaseAndRealTime => & self.base_and_real_time, 
-            RealTimeValidity::BaseOnly => & self.base_only,
-            RealTimeValidity::RealTimeOnly => & self.real_time_only,
+            RealTimeValidity::BaseAndRealTime => &self.base_and_real_time,
+            RealTimeValidity::BaseOnly => &self.base_only,
+            RealTimeValidity::RealTimeOnly => &self.real_time_only,
         };
-        data
-            .get(vehicle_journey_idx)
+        data.get(vehicle_journey_idx)
             .ok_or(Unknown::VehicleJourneyIdx)?
             .has_timetable_on_day(day, days_patterns)
             .ok_or(Unknown::DayForVehicleJourney)
     }
 
-    pub fn insert(&mut self,
+    pub fn insert(
+        &mut self,
         vehicle_journey_idx: &VehicleJourneyIdx,
-        real_time_validity : &RealTimeValidity,
+        real_time_validity: &RealTimeValidity,
         days_pattern_to_insert: &DaysPattern,
         timetable_to_insert: &Timetable,
         days_patterns: &mut DaysPatterns,
-    ) -> Result<(), InsertError>  {
+    ) -> Result<(), InsertError> {
         let data = match *real_time_validity {
-            RealTimeValidity::BaseAndRealTime => & mut self.base_and_real_time, 
-            RealTimeValidity::BaseOnly => & mut self.base_only,
-            RealTimeValidity::RealTimeOnly => & mut self.real_time_only,
+            RealTimeValidity::BaseAndRealTime => &mut self.base_and_real_time,
+            RealTimeValidity::BaseOnly => &mut self.base_only,
+            RealTimeValidity::RealTimeOnly => &mut self.real_time_only,
         };
         data.entry(vehicle_journey_idx.clone())
             .or_insert_with(|| DayToTimetable::new())
@@ -102,22 +102,19 @@ impl VehicleJourneyToTimetable {
         &mut self,
         vehicle_journey_idx: &VehicleJourneyIdx,
         day: &DaysSinceDatasetStart,
-        real_time_validity : &RealTimeValidity,
-        days_patterns: & mut DaysPatterns,
+        real_time_validity: &RealTimeValidity,
+        days_patterns: &mut DaysPatterns,
     ) -> Result<Timetable, Unknown> {
         let data = match *real_time_validity {
-            RealTimeValidity::BaseAndRealTime => &mut self.base_and_real_time, 
+            RealTimeValidity::BaseAndRealTime => &mut self.base_and_real_time,
             RealTimeValidity::BaseOnly => &mut self.base_only,
             RealTimeValidity::RealTimeOnly => &mut self.real_time_only,
         };
-        data
-            .get_mut(vehicle_journey_idx)
+        data.get_mut(vehicle_journey_idx)
             .ok_or(Unknown::VehicleJourneyIdx)?
             .remove(day, days_patterns)
             .map_err(|_| Unknown::DayForVehicleJourney)
     }
-
-
 }
 
 #[derive(Debug)]
@@ -125,7 +122,6 @@ pub enum Unknown {
     VehicleJourneyIdx,
     DayForVehicleJourney,
 }
-
 
 #[derive(Debug)]
 pub struct DayToTimetable {

--- a/src/timetables/generic_timetables.rs
+++ b/src/timetables/generic_timetables.rs
@@ -47,7 +47,6 @@ use FlowDirection::{BoardAndDebark, BoardOnly, DebarkOnly, NoBoardDebark};
 use crate::{
     time::DaysSinceDatasetStart,
     timetables::{FlowDirection, Stop, StopFlows},
-    RealTimeLevel,
 };
 use std::cmp::Ordering::{Greater, Less};
 

--- a/src/timetables/generic_timetables.rs
+++ b/src/timetables/generic_timetables.rs
@@ -996,7 +996,7 @@ where
         nb_to_remove
     }
 
-    pub fn update_vehicles_data<Updater>(&mut self, mut updater: Updater) -> Result<usize, ()>
+    pub fn update_vehicles_data<Updater>(&mut self, mut updater: Updater) -> usize
     where
         Updater: FnMut(&mut VehicleData) -> bool, // returns true when an update took place
     {
@@ -1008,10 +1008,8 @@ where
             }
         }
 
-        match nb_updated {
-            0 => Err(()),
-            _ => Ok(nb_updated),
-        }
+        nb_updated
+
     }
 }
 

--- a/src/timetables/generic_timetables.rs
+++ b/src/timetables/generic_timetables.rs
@@ -1009,7 +1009,6 @@ where
         }
 
         nb_updated
-
     }
 }
 

--- a/src/timetables/generic_timetables.rs
+++ b/src/timetables/generic_timetables.rs
@@ -323,7 +323,6 @@ where
             .map(|timetable| timetable.nb_of_vehicle())
             .sum()
     }
-    
 
     // Insert in the trip in a timetable if
     // the given debark_times, board_times and loads are coherent.

--- a/src/timetables/generic_timetables.rs
+++ b/src/timetables/generic_timetables.rs
@@ -47,6 +47,7 @@ use FlowDirection::{BoardAndDebark, BoardOnly, DebarkOnly, NoBoardDebark};
 use crate::{
     time::DaysSinceDatasetStart,
     timetables::{FlowDirection, Stop, StopFlows},
+    RealTimeLevel,
 };
 use std::cmp::Ordering::{Greater, Less};
 
@@ -269,20 +270,6 @@ where
         timetable_data.earliest_and_latest_debark_time(position.idx)
     }
 
-    pub(super) fn earliest_vehicle_to_board(
-        &self,
-        waiting_time: &Time,
-        timetable: &Timetable,
-        position: &Position,
-    ) -> Option<(Vehicle, &Time, &Load)> {
-        self.earliest_filtered_vehicle_to_board(
-            waiting_time,
-            timetable,
-            position,
-            |_: &VehicleData| true,
-        )
-    }
-
     pub(super) fn earliest_filtered_vehicle_to_board<Filter>(
         &self,
         waiting_time: &Time,
@@ -304,15 +291,6 @@ where
                 let load = self.timetable_data(timetable).load_after(idx, position.idx);
                 (vehicle, time, load)
             })
-    }
-
-    pub(super) fn latest_vehicle_that_debark(
-        &self,
-        time: &Time,
-        timetable: &Timetable,
-        position: &Position,
-    ) -> Option<(Vehicle, &Time, &Load)> {
-        self.latest_filtered_vehicle_that_debark(time, timetable, position, |_| true)
     }
 
     pub(super) fn latest_filtered_vehicle_that_debark<Filter>(

--- a/src/timetables/generic_timetables.rs
+++ b/src/timetables/generic_timetables.rs
@@ -323,6 +323,7 @@ where
             .map(|timetable| timetable.nb_of_vehicle())
             .sum()
     }
+    
 
     // Insert in the trip in a timetable if
     // the given debark_times, board_times and loads are coherent.

--- a/src/timetables/periodic.rs
+++ b/src/timetables/periodic.rs
@@ -611,40 +611,6 @@ impl TimetablesTrait for PeriodicTimetables {
             }
         }
     }
-
-    fn remove_all_vehicle_on_day(&mut self, date: &chrono::NaiveDate) {
-        let day = {
-            let has_day = self.calendar.date_to_days_since_start(date);
-            if let Some(day) = has_day {
-                day
-            } else {
-                warn!(
-                    "Asked to remove all vehicle on day {}, which is invalid for the calendar. \
-                            Allowed dates are between {} and {}",
-                    date,
-                    self.calendar.first_date(),
-                    self.calendar.last_date(),
-                );
-                return;
-            }
-        };
-        let mut vehicle_journeys_to_remove = Vec::new();
-        for (vehicle_journey_idx, day_to_timetable) in self.vehicle_journey_to_timetables.iter() {
-            if day_to_timetable.contains_day(&day, &self.days_patterns) {
-                vehicle_journeys_to_remove.push(vehicle_journey_idx.clone());
-            }
-        }
-        for vehicle_journey_idx in vehicle_journeys_to_remove {
-            let removal_result = self.remove(date, &vehicle_journey_idx);
-            if let Err(removal_error) = removal_result {
-                warn!(
-                    "Removal error occured while removing all vehicles on day {}. \
-                    {:?}",
-                    date, removal_error
-                )
-            }
-        }
-    }
 }
 
 impl<'a> TimetablesIter<'a> for PeriodicTimetables {

--- a/src/timetables/periodic.rs
+++ b/src/timetables/periodic.rs
@@ -37,10 +37,9 @@
 use std::collections::{BTreeMap, HashMap};
 
 use super::{
-    day_to_timetable::{Unknown, VehicleJourneyToTimetable},
     generic_timetables::{self, Position, Timetable, Timetables, Trip, Vehicle, VehicleTimesError},
     iters::{PositionsIter, TimetableIter, VehicleIter},
-    InsertionError, RemovalError, Stop, TimetablesIter,
+    Stop, TimetablesIter,
 };
 
 use crate::{
@@ -511,7 +510,7 @@ impl TimetablesTrait for PeriodicTimetables {
         day: &DaysSinceDatasetStart,
         vehicle_journey_idx: &VehicleJourneyIdx,
         real_time_level: &RealTimeLevel,
-        calendar: &Calendar,
+        _calendar: &Calendar,
         days_patterns: &mut DaysPatterns,
     ) {
         let timetable_data = self.timetables.timetable_data_mut(&mission);

--- a/src/timetables/periodic.rs
+++ b/src/timetables/periodic.rs
@@ -36,7 +36,12 @@
 
 use std::collections::BTreeMap;
 
-use super::{InsertionError, RealTimeValidity, RemovalError, Stop, TimetablesIter, day_to_timetable::{DayToTimetable, Unknown, VehicleJourneyToTimetable}, generic_timetables::{Position, Timetable, Timetables, Trip, Vehicle}, iters::{PositionsIter, TimetableIter, VehicleIter}};
+use super::{
+    day_to_timetable::{DayToTimetable, Unknown, VehicleJourneyToTimetable},
+    generic_timetables::{Position, Timetable, Timetables, Trip, Vehicle},
+    iters::{PositionsIter, TimetableIter, VehicleIter},
+    InsertionError, RealTimeValidity, RemovalError, Stop, TimetablesIter,
+};
 
 use crate::{
     loads_data::LoadsData,
@@ -462,29 +467,47 @@ impl TimetablesTrait for PeriodicTimetables {
         for date in valid_dates.clone() {
             let has_day = self.calendar.date_to_days_since_start(date);
             if let Some(day) = has_day {
-                if self.vehicle_journey_to_timetable.get_timetable(vehicle_journey_idx, &day, real_time_validity, &self.days_patterns).is_ok() {
-                    let error = InsertionError::VehicleJourneyAlreadyExistsOnDate(date.clone(), vehicle_journey_idx.clone(), real_time_validity.clone());
+                if self
+                    .vehicle_journey_to_timetable
+                    .get_timetable(
+                        vehicle_journey_idx,
+                        &day,
+                        real_time_validity,
+                        &self.days_patterns,
+                    )
+                    .is_ok()
+                {
+                    let error = InsertionError::VehicleJourneyAlreadyExistsOnDate(
+                        date.clone(),
+                        vehicle_journey_idx.clone(),
+                        real_time_validity.clone(),
+                    );
                     insertion_errors.push(error);
                 }
-            }
-            else {
+            } else {
                 let error = InsertionError::InvalidDate(date.clone(), vehicle_journey_idx.clone());
                 insertion_errors.push(error);
             }
-            
         }
 
         let valid_dates = valid_dates.filter(|date| {
             let has_day = self.calendar.date_to_days_since_start(date);
             if let Some(day) = has_day {
-                if self.vehicle_journey_to_timetable.get_timetable(vehicle_journey_idx, &day, real_time_validity, &self.days_patterns).is_ok() {
+                if self
+                    .vehicle_journey_to_timetable
+                    .get_timetable(
+                        vehicle_journey_idx,
+                        &day,
+                        real_time_validity,
+                        &self.days_patterns,
+                    )
+                    .is_ok()
+                {
                     false
-                }
-                else {
+                } else {
                     true
                 }
-            }
-            else {
+            } else {
                 false
             }
         });
@@ -517,7 +540,7 @@ impl TimetablesTrait for PeriodicTimetables {
             let vehicle_data = VehicleData {
                 days_pattern,
                 vehicle_journey_idx: vehicle_journey_idx.clone(),
-                real_time_validity : real_time_validity.clone()
+                real_time_validity: real_time_validity.clone(),
             };
             let insert_result = self.timetables.insert(
                 stops.clone(),
@@ -534,18 +557,21 @@ impl TimetablesTrait for PeriodicTimetables {
                         missions.push(mission.clone());
                     };
                     let has_err = self.vehicle_journey_to_timetable.insert(
-                        vehicle_journey_idx, 
-                        real_time_validity, 
-                        &days_pattern, 
+                        vehicle_journey_idx,
+                        real_time_validity,
+                        &days_pattern,
                         &mission,
                         &mut self.days_patterns,
                     );
-                    // we filtered valid_dates 
+                    // we filtered valid_dates
                     // so that it does not contains a date on which (vehicle_jounrney, real_time_validity)
                     // was already mapped to a timetable in self.vehicle_journey_to_timetable
                     // so this error should never occurs, but let's log a warning if it happens
                     if let Err(err) = has_err {
-                        error!("Error occured while inserting a vehicle journey in timetables : {:?}", err);
+                        error!(
+                            "Error occured while inserting a vehicle journey in timetables : {:?}",
+                            err
+                        );
                     }
                 }
                 Err(times_error) => {
@@ -569,20 +595,36 @@ impl TimetablesTrait for PeriodicTimetables {
         let day = self
             .calendar
             .date_to_days_since_start(date)
-            .ok_or_else(|| RemovalError::UnknownDate(*date, vehicle_journey_idx.clone(), real_time_validity.clone()))?;
-
-        let timetable = self.vehicle_journey_to_timetable
-            .get_timetable(vehicle_journey_idx, &day, real_time_validity, &self.days_patterns)
-            .map_err(|err| {
-                match err {
-                    Unknown::VehicleJourneyIdx => RemovalError::UnknownVehicleJourney(vehicle_journey_idx.clone(), real_time_validity.clone()),
-                    Unknown::DayForVehicleJourney => RemovalError::DateInvalidForVehicleJourney(date.clone(), vehicle_journey_idx.clone(), real_time_validity.clone()),
-                }
+            .ok_or_else(|| {
+                RemovalError::UnknownDate(
+                    *date,
+                    vehicle_journey_idx.clone(),
+                    real_time_validity.clone(),
+                )
             })?;
 
-    
+        let timetable = self
+            .vehicle_journey_to_timetable
+            .get_timetable(
+                vehicle_journey_idx,
+                &day,
+                real_time_validity,
+                &self.days_patterns,
+            )
+            .map_err(|err| match err {
+                Unknown::VehicleJourneyIdx => RemovalError::UnknownVehicleJourney(
+                    vehicle_journey_idx.clone(),
+                    real_time_validity.clone(),
+                ),
+                Unknown::DayForVehicleJourney => RemovalError::DateInvalidForVehicleJourney(
+                    date.clone(),
+                    vehicle_journey_idx.clone(),
+                    real_time_validity.clone(),
+                ),
+            })?;
+
         let timetable_data = self.timetables.timetable_data_mut(&timetable);
-    
+
         let days_patterns = &mut self.days_patterns;
         let nb_vehicle_updated = timetable_data.update_vehicles_data(|vehicle_data| {
             if vehicle_data.vehicle_journey_idx == *vehicle_journey_idx
@@ -592,7 +634,7 @@ impl TimetablesTrait for PeriodicTimetables {
                 vehicle_data.days_pattern = days_patterns
                     .get_pattern_without_day(vehicle_data.days_pattern, &day)
                     .unwrap(); // unwrap is safe, because we check above that
-                                // vehicle_data.days_pattern contains day
+                               // vehicle_data.days_pattern contains day
                 true
             } else {
                 false
@@ -612,22 +654,27 @@ impl TimetablesTrait for PeriodicTimetables {
             error!("Removed {} vehicle during removal of one (vehicle_journey_idx, real_time_validity, day).", nb_vehicle_removed);
         }
 
-        let removal_result = self.vehicle_journey_to_timetable
-            .remove(vehicle_journey_idx, &day, real_time_validity, &mut self.days_patterns);
-
+        let removal_result = self.vehicle_journey_to_timetable.remove(
+            vehicle_journey_idx,
+            &day,
+            real_time_validity,
+            &mut self.days_patterns,
+        );
 
         match removal_result {
-            Ok(_) => {},
+            Ok(_) => {}
             Err(err) => {
-                // we checked at the beginning that self.vehicle_journey_to_timetable 
+                // we checked at the beginning that self.vehicle_journey_to_timetable
                 // does contains a timetable for (vehicle_journey_idx, &day, real_time_validity)
                 // so this error should never occurs, but let's log a warning if it happens
-                error!("Error occured while removing a vehicle journey in timetables : {:?}", err);
+                error!(
+                    "Error occured while removing a vehicle journey in timetables : {:?}",
+                    err
+                );
             }
         }
 
         Ok(())
-
     }
 }
 

--- a/src/timetables/periodic.rs
+++ b/src/timetables/periodic.rs
@@ -545,7 +545,7 @@ impl TimetablesTrait for PeriodicTimetables {
                     // was already mapped to a timetable in self.vehicle_journey_to_timetable
                     // so this error should never occurs, but let's log a warning if it happens
                     if let Err(err) = has_err {
-                        error!("Error occured while inserting a vehicle journey in timetables : insertion occured on a day already set.");
+                        error!("Error occured while inserting a vehicle journey in timetables : {:?}", err);
                     }
                 }
                 Err(times_error) => {
@@ -622,7 +622,7 @@ impl TimetablesTrait for PeriodicTimetables {
                 // we checked at the beginning that self.vehicle_journey_to_timetable 
                 // does contains a timetable for (vehicle_journey_idx, &day, real_time_validity)
                 // so this error should never occurs, but let's log a warning if it happens
-                error!("Error occured while removing a vehicle journey in timetables : removal occured on a day already not set.");
+                error!("Error occured while removing a vehicle journey in timetables : {:?}", err);
             }
         }
 

--- a/src/timetables/periodic.rs
+++ b/src/timetables/periodic.rs
@@ -80,9 +80,7 @@ impl TimetablesTypes for PeriodicTimetables {
 }
 
 impl TimetablesTrait for PeriodicTimetables {
-    fn new(first_date: NaiveDate, last_date: NaiveDate) -> Self {
-        let calendar = Calendar::new(first_date, last_date);
-        let nb_of_days: usize = calendar.nb_of_days().into();
+    fn new() -> Self {
         Self {
             timetables: Timetables::new(),
         }

--- a/src/timetables/periodic.rs
+++ b/src/timetables/periodic.rs
@@ -105,7 +105,7 @@ impl TimetablesTrait for PeriodicTimetables {
     }
 
     fn day_of(&self, trip: &Self::Trip) -> DaysSinceDatasetStart {
-        trip.day.clone()
+        trip.day
     }
 
     fn mission_of(&self, trip: &Self::Trip) -> Self::Mission {
@@ -486,7 +486,7 @@ impl TimetablesTrait for PeriodicTimetables {
                 Ok(mission) => {
                     let pattern = result
                         .entry(mission)
-                        .or_insert(days_patterns.empty_pattern());
+                        .or_insert_with(|| days_patterns.empty_pattern());
                     *pattern = days_patterns.get_union(*pattern, days_pattern);
                 }
                 Err(times_error) => {
@@ -513,7 +513,7 @@ impl TimetablesTrait for PeriodicTimetables {
         _calendar: &Calendar,
         days_patterns: &mut DaysPatterns,
     ) {
-        let timetable_data = self.timetables.timetable_data_mut(&mission);
+        let timetable_data = self.timetables.timetable_data_mut(mission);
 
         let nb_vehicle_updated = timetable_data.update_vehicles_data(|vehicle_data| {
             let days_pattern = match real_time_level {
@@ -521,10 +521,10 @@ impl TimetablesTrait for PeriodicTimetables {
                 RealTimeLevel::RealTime => &mut vehicle_data.real_time_days_pattern,
             };
             if vehicle_data.vehicle_journey_idx == *vehicle_journey_idx
-                && days_patterns.is_allowed(&days_pattern, &day)
+                && days_patterns.is_allowed(days_pattern, day)
             {
                 *days_pattern = days_patterns
-                    .get_pattern_without_day(*days_pattern, &day)
+                    .get_pattern_without_day(*days_pattern, day)
                     .unwrap(); // unwrap is safe, because we check above that
                                // vehicle_data.days_pattern contains day
                 true

--- a/src/timetables/periodic.rs
+++ b/src/timetables/periodic.rs
@@ -52,6 +52,7 @@ use crate::{
         SecondsSinceTimezonedDayStart,
     },
     timetables::{FlowDirection, Timetables as TimetablesTrait, Types as TimetablesTypes},
+    RealTimeLevel,
 };
 use chrono::NaiveDate;
 use chrono_tz::Tz as TimeZone;
@@ -218,8 +219,15 @@ impl TimetablesTrait for PeriodicTimetables {
         waiting_time: &SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)> {
-        self.earliest_filtered_trip_to_board_at(waiting_time, mission, position, |_| true)
+        self.earliest_filtered_trip_to_board_at(
+            waiting_time,
+            mission,
+            position,
+            real_time_level,
+            |_| true,
+        )
     }
 
     fn earliest_filtered_trip_to_board_at<Filter>(
@@ -227,6 +235,7 @@ impl TimetablesTrait for PeriodicTimetables {
         waiting_time: &SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
         filter: Filter,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>
     where
@@ -265,6 +274,9 @@ impl TimetablesTrait for PeriodicTimetables {
                     let days_pattern = vehicle_data.days_pattern;
                     self.days_patterns.is_allowed(&days_pattern, &waiting_day)
                         && filter(&vehicle_data.vehicle_journey_idx)
+                        && vehicle_data
+                            .real_time_validity
+                            .is_valid_for(real_time_level)
                 },
             );
             if let Some((vehicle, arrival_time_in_day_at_next_stop, load)) = has_vehicle {
@@ -301,70 +313,9 @@ impl TimetablesTrait for PeriodicTimetables {
         time: &SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)> {
-        let has_earliest_and_latest_debark_time =
-            self.timetables.earliest_and_latest_debark_time(position);
-
-        // if there is no earliest/latest debark time, it means that this position cannot be debarked
-        // and we return None
-        let (_earliest_debark_time_in_day, _latest_debark_time_in_day) =
-            has_earliest_and_latest_debark_time?;
-
-        let timezone = self.timetables.timezone_data(mission);
-
-        let decompositions = self.calendar.decompositions(
-            time,
-            timezone,
-            SecondsSinceTimezonedDayStart::max(),
-            SecondsSinceTimezonedDayStart::min(),
-            // *latest_debark_time_in_day,
-            // *earliest_debark_time_in_day,
-        );
-        let mut best_vehicle_day_and_its_departure_time_at_previous_position: Option<(
-            Vehicle,
-            DaysSinceDatasetStart,
-            SecondsSinceDatasetUTCStart,
-            Load,
-        )> = None;
-        for (waiting_day, waiting_time_in_day) in decompositions {
-            let has_vehicle = self.timetables.latest_filtered_vehicle_that_debark(
-                &waiting_time_in_day,
-                mission,
-                position,
-                |vehicle_data| {
-                    let days_pattern = vehicle_data.days_pattern;
-                    self.days_patterns.is_allowed(&days_pattern, &waiting_day)
-                },
-            );
-            if let Some((vehicle, departure_time_in_day_at_previous_stop, load)) = has_vehicle {
-                let departure_time_at_previous_stop = self.calendar.compose(
-                    &waiting_day,
-                    departure_time_in_day_at_previous_stop,
-                    timezone,
-                );
-                if let Some((_, _, best_departure_time, best_load)) =
-                    &best_vehicle_day_and_its_departure_time_at_previous_position
-                {
-                    if departure_time_at_previous_stop > *best_departure_time
-                        || (departure_time_at_previous_stop == *best_departure_time
-                            && load < best_load)
-                    {
-                        best_vehicle_day_and_its_departure_time_at_previous_position =
-                            Some((vehicle, waiting_day, departure_time_at_previous_stop, *load));
-                    }
-                } else {
-                    best_vehicle_day_and_its_departure_time_at_previous_position =
-                        Some((vehicle, waiting_day, departure_time_at_previous_stop, *load));
-                }
-            }
-        }
-
-        best_vehicle_day_and_its_departure_time_at_previous_position.map(
-            |(vehicle, day, departure_time_at_previous_stop, load)| {
-                let trip = Trip { vehicle, day };
-                (trip, departure_time_at_previous_stop, load)
-            },
-        )
+        self.latest_filtered_trip_that_debark_at(time, mission, position, real_time_level, |_| true)
     }
 
     fn latest_filtered_trip_that_debark_at<Filter>(
@@ -372,6 +323,7 @@ impl TimetablesTrait for PeriodicTimetables {
         time: &SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
         filter: Filter,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>
     where
@@ -410,6 +362,9 @@ impl TimetablesTrait for PeriodicTimetables {
                     let days_pattern = vehicle_data.days_pattern;
                     self.days_patterns.is_allowed(&days_pattern, &waiting_day)
                         && filter(&vehicle_data.vehicle_journey_idx)
+                        && vehicle_data
+                            .real_time_validity
+                            .is_valid_for(real_time_level)
                 },
             );
             if let Some((vehicle, departure_time_in_day_at_previous_stop, load)) = has_vehicle {

--- a/src/timetables/periodic_split_vj_by_tz.rs
+++ b/src/timetables/periodic_split_vj_by_tz.rs
@@ -411,14 +411,14 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
                     .is_ok()
                 {
                     let error = InsertionError::VehicleJourneyAlreadyExistsOnDate(
-                        date.clone(),
+                        *date,
                         vehicle_journey_idx.clone(),
                         real_time_validity.clone(),
                     );
                     insertion_errors.push(error);
                 }
             } else {
-                let error = InsertionError::InvalidDate(date.clone(), vehicle_journey_idx.clone());
+                let error = InsertionError::InvalidDate(*date, vehicle_journey_idx.clone());
                 insertion_errors.push(error);
             }
         }
@@ -426,20 +426,14 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
         let valid_dates = valid_dates.filter(|date| {
             let has_day = self.calendar.date_to_days_since_start(date);
             if let Some(day) = has_day {
-                if self
-                    .vehicle_journey_to_timetable
+                self.vehicle_journey_to_timetable
                     .get_timetable(
                         vehicle_journey_idx,
                         &day,
                         real_time_validity,
                         &self.days_patterns,
                     )
-                    .is_ok()
-                {
-                    false
-                } else {
-                    true
-                }
+                    .is_err()
             } else {
                 false
             }
@@ -559,7 +553,7 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
                     real_time_validity.clone(),
                 ),
                 Unknown::DayForVehicleJourney => RemovalError::DateInvalidForVehicleJourney(
-                    date.clone(),
+                    *date,
                     vehicle_journey_idx.clone(),
                     real_time_validity.clone(),
                 ),

--- a/src/timetables/periodic_split_vj_by_tz.rs
+++ b/src/timetables/periodic_split_vj_by_tz.rs
@@ -473,7 +473,7 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
                         // was already mapped to a timetable in self.vehicle_journey_to_timetable
                         // so this error should never occurs, but let's log a warning if it happens
                         if let Err(err) = has_err {
-                            error!("Error occured while inserting a vehicle journey in timetables : insertion occured on a day already set.");
+                            error!("Error occured while inserting a vehicle journey in timetables : {:?}", err);
                         }
  
                     }
@@ -552,7 +552,7 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
                 // we checked at the beginning that self.vehicle_journey_to_timetable 
                 // does contains a timetable for (vehicle_journey_idx, &day, real_time_validity)
                 // so this error should never occurs, but let's log a warning if it happens
-                error!("Error occured while removing a vehicle journey in timetables : removal occured on a day already not set.");
+                error!("Error occured while removing a vehicle journey in timetables : {:?}", err);
             }
         }
 

--- a/src/timetables/periodic_split_vj_by_tz.rs
+++ b/src/timetables/periodic_split_vj_by_tz.rs
@@ -447,7 +447,7 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
                     time_in_timezoned_day.to_utc(offset)
                 };
 
-                let insert_error = self.timetables.insert(
+                let insert_result = self.timetables.insert(
                     stops.clone(),
                     flows.clone(),
                     board_times.clone().map(apply_offset),
@@ -456,7 +456,7 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
                     (),
                     vehicle_data,
                 );
-                match insert_error {
+                match insert_result {
                     Ok(mission) => {
                         if !missions.contains(&mission) {
                             missions.push(mission.clone());
@@ -556,7 +556,7 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
             }
         }
 
-        return Ok(());
+        Ok(())
 
     }
 }

--- a/src/timetables/periodic_split_vj_by_tz.rs
+++ b/src/timetables/periodic_split_vj_by_tz.rs
@@ -43,9 +43,8 @@ use crate::{
 };
 
 use super::{
-    day_to_timetable::{Unknown, VehicleJourneyToTimetable},
     generic_timetables::{Timetables, Trip, Vehicle, VehicleTimesError},
-    InsertionError, ModifyError, RemovalError, TimetablesIter,
+    TimetablesIter,
 };
 use crate::time::{
     Calendar, DaysSinceDatasetStart, SecondsSinceDatasetUTCStart, SecondsSinceTimezonedDayStart,
@@ -53,7 +52,6 @@ use crate::time::{
 };
 use crate::timetables::generic_timetables::{Position, Timetable};
 use chrono::NaiveDate;
-use core::cmp;
 use std::collections::{BTreeMap, HashMap};
 use tracing::log::error;
 
@@ -511,7 +509,7 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
         day: &DaysSinceDatasetStart,
         vehicle_journey_idx: &VehicleJourneyIdx,
         real_time_level: &RealTimeLevel,
-        calendar: &Calendar,
+        _calendar: &Calendar,
         days_patterns: &mut DaysPatterns,
     ) {
         let timetable_data = self.timetables.timetable_data_mut(&timetable);

--- a/src/timetables/periodic_split_vj_by_tz.rs
+++ b/src/timetables/periodic_split_vj_by_tz.rs
@@ -405,7 +405,11 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
         let mut load_patterns_dates: BTreeMap<&[Load], Vec<NaiveDate>> = BTreeMap::new();
 
         let nb_of_positions = stops.len();
-        let default_loads = vec![Load::default(); cmp::max(nb_of_positions - 1, 0)];
+        let default_loads = if nb_of_positions > 0 {
+            vec![Load::default(); nb_of_positions - 1]
+        } else {
+            vec![Load::default(); 0]
+        };
         for date in days_patterns.make_dates(days, calendar) {
             let loads = loads_data
                 .loads(&vehicle_journey_idx.clone(), &date)

--- a/src/timetables/periodic_split_vj_by_tz.rs
+++ b/src/timetables/periodic_split_vj_by_tz.rs
@@ -80,9 +80,7 @@ impl TimetablesTypes for PeriodicSplitVjByTzTimetables {
 }
 
 impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
-    fn new(first_date: NaiveDate, last_date: NaiveDate) -> Self {
-        let calendar = Calendar::new(first_date, last_date);
-        let nb_of_days: usize = calendar.nb_of_days().into();
+    fn new() -> Self {
         Self {
             timetables: Timetables::new(),
             timezones_patterns: TimezonesPatterns::new(),

--- a/src/timetables/periodic_split_vj_by_tz.rs
+++ b/src/timetables/periodic_split_vj_by_tz.rs
@@ -66,7 +66,7 @@ pub struct PeriodicSplitVjByTzTimetables {
     calendar: Calendar,
     days_patterns: DaysPatterns,
     timezones_patterns: TimezonesPatterns,
-    vehicle_journey_to_timetable: VehicleJourneyToTimetable,
+    vehicle_journey_to_timetable: VehicleJourneyToTimetable<Timetable>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/timetables/periodic_split_vj_by_tz.rs
+++ b/src/timetables/periodic_split_vj_by_tz.rs
@@ -105,7 +105,7 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
     }
 
     fn day_of(&self, trip: &Self::Trip) -> DaysSinceDatasetStart {
-        trip.day.clone()
+        trip.day
     }
 
     fn mission_of(&self, trip: &Self::Trip) -> Self::Mission {
@@ -485,7 +485,7 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
                     Ok(mission) => {
                         let pattern = result
                             .entry(mission)
-                            .or_insert(days_patterns.empty_pattern());
+                            .or_insert_with(|| days_patterns.empty_pattern());
                         *pattern = days_patterns.get_union(*pattern, days_pattern);
                     }
                     Err(times_error) => {
@@ -512,7 +512,7 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
         _calendar: &Calendar,
         days_patterns: &mut DaysPatterns,
     ) {
-        let timetable_data = self.timetables.timetable_data_mut(&timetable);
+        let timetable_data = self.timetables.timetable_data_mut(timetable);
 
         let nb_vehicle_updated =
             timetable_data.update_vehicles_data(|vehicle_data: &mut VehicleData| {
@@ -521,10 +521,10 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
                     RealTimeLevel::RealTime => &mut vehicle_data.real_time_days_pattern,
                 };
                 if vehicle_data.vehicle_journey_idx == *vehicle_journey_idx
-                    && days_patterns.is_allowed(&days_pattern, &day)
+                    && days_patterns.is_allowed(days_pattern, day)
                 {
                     *days_pattern = days_patterns
-                        .get_pattern_without_day(*days_pattern, &day)
+                        .get_pattern_without_day(*days_pattern, day)
                         .unwrap(); // unwrap is safe, because we check above that
                                    // days_patterns.is_allowed(&days_pattern, &day)
                     true

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -41,7 +41,16 @@ pub mod iters;
 use chrono::NaiveDate;
 use iters::MissionsOfStop;
 
-use crate::{RealTimeLevel, loads_data::{Load, LoadsData}, models::{base_model::BaseModel, ModelRefs, StopPointIdx, TransferIdx, VehicleJourneyIdx}, time::{Calendar, PositiveDuration, SecondsSinceDatasetUTCStart}, timetables::{InsertionError, ModifyError, generic_timetables::{PositionPair, VehicleTimesError}}};
+use crate::{
+    loads_data::{Load, LoadsData},
+    models::{base_model::BaseModel, ModelRefs, StopPointIdx, TransferIdx, VehicleJourneyIdx},
+    time::{Calendar, PositiveDuration, SecondsSinceDatasetUTCStart},
+    timetables::{
+        generic_timetables::{PositionPair, VehicleTimesError},
+        InsertionError, ModifyError,
+    },
+    RealTimeLevel,
+};
 
 use std::{collections::HashMap, fmt::Debug};
 
@@ -311,7 +320,7 @@ where
 
 impl<Timetables: TimetablesTrait> data_interface::DataIO for TransitData<Timetables>
 where
-    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> ,
+    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a>,
 {
     fn new(
         base_model: &BaseModel,
@@ -346,14 +355,18 @@ where
 
     type TripsOfMission = <Timetables as TimetablesIter<'a>>::Trips;
 
-    fn trips_of(&'a self, mission: &Self::Mission, real_time_level : &RealTimeLevel) -> Self::TripsOfMission {
+    fn trips_of(
+        &'a self,
+        mission: &Self::Mission,
+        real_time_level: &RealTimeLevel,
+    ) -> Self::TripsOfMission {
         self.timetables.trips_of(mission, real_time_level)
     }
 }
 
 impl<Timetables> data_interface::DataWithIters for TransitData<Timetables>
 where
-    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> ,
+    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a>,
     Timetables::Mission: 'static,
     Timetables::Position: 'static,
 {
@@ -365,36 +378,34 @@ pub fn handle_insertion_error(
     end_date: &NaiveDate,
     insertion_error: &InsertionError,
 ) {
-
-        use crate::timetables::InsertionError::*;
-        match insertion_error {
-            Times(vehicle_journey_idx, error, dates) => {
-                let _ = handle_vehicletimes_error(vehicle_journey_idx, dates, model, error);
-            }
-            RealTimeVehicleJourneyAlreadyExistsOnDate(date, vehicle_journey_idx) => {
-                let vehicle_journey_name = model.vehicle_journey_name(vehicle_journey_idx);
-                error!(
-                    "Trying to insert the real time vehicle journey {} more than once on day {}",
-                    vehicle_journey_name, date
-                );
-            }
-            InvalidDate(date, vehicle_journey_idx) => {
-                let vehicle_journey_name = model.vehicle_journey_name(vehicle_journey_idx);
-                error!(
-                    "Trying to insert the vehicle journey {} on day {},  \
+    use crate::timetables::InsertionError::*;
+    match insertion_error {
+        Times(vehicle_journey_idx, error, dates) => {
+            let _ = handle_vehicletimes_error(vehicle_journey_idx, dates, model, error);
+        }
+        RealTimeVehicleJourneyAlreadyExistsOnDate(date, vehicle_journey_idx) => {
+            let vehicle_journey_name = model.vehicle_journey_name(vehicle_journey_idx);
+            error!(
+                "Trying to insert the real time vehicle journey {} more than once on day {}",
+                vehicle_journey_name, date
+            );
+        }
+        InvalidDate(date, vehicle_journey_idx) => {
+            let vehicle_journey_name = model.vehicle_journey_name(vehicle_journey_idx);
+            error!(
+                "Trying to insert the vehicle journey {} on day {},  \
                         but this day is not allowed in the date.  \
                         Allowed dates are between {} and {}",
-                    vehicle_journey_name, date, start_date, end_date,
-                );
-            }
-            BaseVehicleJourneyAlreadyExists(vehicle_journey_idx) => {
-                let vehicle_journey_name = model.vehicle_journey_name(vehicle_journey_idx);
-                error!(
-                    "Trying to insert the base vehicle journey {} more than once.",
-                    vehicle_journey_name
-                );
-            },
-        
+                vehicle_journey_name, date, start_date, end_date,
+            );
+        }
+        BaseVehicleJourneyAlreadyExists(vehicle_journey_idx) => {
+            let vehicle_journey_name = model.vehicle_journey_name(vehicle_journey_idx);
+            error!(
+                "Trying to insert the base vehicle journey {} more than once.",
+                vehicle_journey_name
+            );
+        }
     }
 }
 
@@ -514,7 +525,6 @@ pub fn handle_removal_error(
     end_date: &NaiveDate,
     error: &RemovalError,
 ) {
-
     match error {
         RemovalError::UnknownDate(date, vehicle_journey_idx) => {
             let vehicle_journey_name = model.vehicle_journey_name(&vehicle_journey_idx);
@@ -533,10 +543,7 @@ pub fn handle_removal_error(
                 vehicle_journey_name
             );
         }
-        RemovalError::DateInvalidForVehicleJourney(
-            date,
-            vehicle_journey_idx,
-        ) => {
+        RemovalError::DateInvalidForVehicleJourney(date, vehicle_journey_idx) => {
             let vehicle_journey_name = model.vehicle_journey_name(&vehicle_journey_idx);
             error!(
                 "Trying to remove the vehicle journey {} on day {},  \
@@ -547,16 +554,12 @@ pub fn handle_removal_error(
     }
 }
 
-
-
-
 pub fn handle_modify_error(
     model: &ModelRefs,
     start_date: &NaiveDate,
     end_date: &NaiveDate,
     modify_error: &ModifyError,
 ) {
-
     match modify_error {
         ModifyError::UnknownDate(date, vehicle_journey_idx) => {
             let vehicle_journey_name = model.vehicle_journey_name(&vehicle_journey_idx);
@@ -575,10 +578,7 @@ pub fn handle_modify_error(
                 vehicle_journey_name
             );
         }
-        ModifyError::DateInvalidForVehicleJourney(
-            date,
-            vehicle_journey_idx,
-        ) => {
+        ModifyError::DateInvalidForVehicleJourney(date, vehicle_journey_idx) => {
             let vehicle_journey_name = model.vehicle_journey_name(&vehicle_journey_idx);
             error!(
                 "Trying to modify the vehicle journey {} on day {},  \
@@ -588,8 +588,6 @@ pub fn handle_modify_error(
         }
         ModifyError::Times(vehicle_journey_idx, times_err, dates) => {
             let _ = handle_vehicletimes_error(vehicle_journey_idx, dates, model, times_err);
-        },
+        }
     }
-
 }
-

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -49,6 +49,7 @@ use crate::{
         generic_timetables::{PositionPair, VehicleTimesError},
         InsertionError,
     },
+    RealTimeLevel,
 };
 
 use std::{collections::HashMap, fmt::Debug};
@@ -204,9 +205,10 @@ where
         waiting_time: &crate::time::SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)> {
         self.timetables
-            .earliest_trip_to_board_at(waiting_time, mission, position)
+            .earliest_trip_to_board_at(waiting_time, mission, position, real_time_level)
     }
 
     fn earliest_filtered_trip_to_board_at<Filter>(
@@ -214,13 +216,19 @@ where
         waiting_time: &SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
         filter: Filter,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>
     where
         Filter: Fn(&VehicleJourneyIdx) -> bool,
     {
-        self.timetables
-            .earliest_filtered_trip_to_board_at(waiting_time, mission, position, filter)
+        self.timetables.earliest_filtered_trip_to_board_at(
+            waiting_time,
+            mission,
+            position,
+            real_time_level,
+            filter,
+        )
     }
 
     fn latest_trip_that_debark_at(
@@ -228,9 +236,10 @@ where
         waiting_time: &crate::time::SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)> {
         self.timetables
-            .latest_trip_that_debark_at(waiting_time, mission, position)
+            .latest_trip_that_debark_at(waiting_time, mission, position, real_time_level)
     }
 
     fn latest_filtered_trip_that_debark_at<Filter>(
@@ -238,13 +247,19 @@ where
         waiting_time: &crate::time::SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
         filter: Filter,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>
     where
         Filter: Fn(&VehicleJourneyIdx) -> bool,
     {
-        self.timetables
-            .latest_filtered_trip_that_debark_at(waiting_time, mission, position, filter)
+        self.timetables.latest_filtered_trip_that_debark_at(
+            waiting_time,
+            mission,
+            position,
+            real_time_level,
+            filter,
+        )
     }
 
     fn to_naive_datetime(

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -555,7 +555,7 @@ pub fn handle_removal_error(
 ) {
     match error {
         RemovalError::UnknownDate(date, vehicle_journey_idx) => {
-            let vehicle_journey_name = model.vehicle_journey_name(&vehicle_journey_idx);
+            let vehicle_journey_name = model.vehicle_journey_name(vehicle_journey_idx);
             error!(
                 "Trying to remove the vehicle journey {} on day {},  \
                     but this day is not allowed in the data.  \
@@ -564,7 +564,7 @@ pub fn handle_removal_error(
             );
         }
         RemovalError::UnknownVehicleJourney(vehicle_journey_idx) => {
-            let vehicle_journey_name = model.vehicle_journey_name(&vehicle_journey_idx);
+            let vehicle_journey_name = model.vehicle_journey_name(vehicle_journey_idx);
             error!(
                 "Trying to remove the vehicle journey {} \
                     but this vehicle journey is unknown",
@@ -572,7 +572,7 @@ pub fn handle_removal_error(
             );
         }
         RemovalError::DateInvalidForVehicleJourney(date, vehicle_journey_idx) => {
-            let vehicle_journey_name = model.vehicle_journey_name(&vehicle_journey_idx);
+            let vehicle_journey_name = model.vehicle_journey_name(vehicle_journey_idx);
             error!(
                 "Trying to remove the vehicle journey {} on day {},  \
                     but this vehicle journeys does not exists on this day. ",
@@ -590,7 +590,7 @@ pub fn handle_modify_error(
 ) {
     match modify_error {
         ModifyError::UnknownDate(date, vehicle_journey_idx) => {
-            let vehicle_journey_name = model.vehicle_journey_name(&vehicle_journey_idx);
+            let vehicle_journey_name = model.vehicle_journey_name(vehicle_journey_idx);
             error!(
                 "Trying to modify the vehicle journey {} on day {},  \
                     but this day is not allowed in the data.  \
@@ -599,7 +599,7 @@ pub fn handle_modify_error(
             );
         }
         ModifyError::UnknownVehicleJourney(vehicle_journey_idx) => {
-            let vehicle_journey_name = model.vehicle_journey_name(&vehicle_journey_idx);
+            let vehicle_journey_name = model.vehicle_journey_name(vehicle_journey_idx);
             error!(
                 "Trying to modify the vehicle journey {} \
                     but this vehicle journey is unknown",
@@ -607,7 +607,7 @@ pub fn handle_modify_error(
             );
         }
         ModifyError::DateInvalidForVehicleJourney(date, vehicle_journey_idx) => {
-            let vehicle_journey_name = model.vehicle_journey_name(&vehicle_journey_idx);
+            let vehicle_journey_name = model.vehicle_journey_name(vehicle_journey_idx);
             error!(
                 "Trying to modify the vehicle journey {} on day {},  \
                     but this vehicle journeys does not exists on this day. ",

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -64,9 +64,6 @@ pub struct TransitData<Timetables: TimetablesTrait> {
     pub(super) timetables: Timetables,
 
     pub(super) transfers_data: Vec<TransferData>,
-
-    pub(super) start_date: NaiveDate,
-    pub(super) end_date: NaiveDate,
 }
 
 pub struct StopData<Timetables: TimetablesTrait> {

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -44,8 +44,9 @@ use iters::MissionsOfStop;
 use crate::{
     loads_data::{Load, LoadsData},
     models::{base_model::BaseModel, ModelRefs, StopPointIdx, TransferIdx, VehicleJourneyIdx},
-    time::{Calendar, PositiveDuration, SecondsSinceDatasetUTCStart},
+    time::{days_patterns::DaysPatterns, Calendar, PositiveDuration, SecondsSinceDatasetUTCStart},
     timetables::{
+        day_to_timetable::VehicleJourneyToTimetable,
         generic_timetables::{PositionPair, VehicleTimesError},
         InsertionError, ModifyError,
     },
@@ -65,6 +66,11 @@ pub struct TransitData<Timetables: TimetablesTrait> {
     pub(super) timetables: Timetables,
 
     pub(super) transfers_data: Vec<TransferData>,
+
+    pub(super) vehicle_journey_to_timetable: VehicleJourneyToTimetable<Timetables::Mission>,
+
+    pub(super) calendar: Calendar,
+    pub(super) days_patterns: DaysPatterns,
 }
 
 pub struct StopData<Timetables: TimetablesTrait> {

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -326,14 +326,8 @@ where
         base_model: &BaseModel,
         loads_data: &LoadsData,
         default_transfer_duration: PositiveDuration,
-        restrict_calendar: Option<(NaiveDate, NaiveDate)>,
     ) -> Self {
-        Self::_new(
-            base_model,
-            loads_data,
-            default_transfer_duration,
-            restrict_calendar,
-        )
+        Self::_new(base_model, loads_data, default_transfer_duration)
     }
 }
 

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -371,11 +371,11 @@ pub fn handle_insertion_errors(
             Times(vehicle_journey_idx, error, dates) => {
                 let _ = handle_vehicletimes_error(vehicle_journey_idx, dates, model, error);
             }
-            VehicleJourneyAlreadyExistsOnDate(date, vehicle_journey_idx) => {
+            VehicleJourneyAlreadyExistsOnDate(date, vehicle_journey_idx, real_time_validity) => {
                 let vehicle_journey_name = model.vehicle_journey_name(vehicle_journey_idx);
                 error!(
-                    "Trying to insert the vehicle journey {} more than once on day {}",
-                    vehicle_journey_name, date
+                    "Trying to insert the vehicle journey {} {:?} more than once on day {}",
+                    vehicle_journey_name, real_time_validity, date
                 );
             }
             InvalidDate(date, vehicle_journey_idx) => {
@@ -509,29 +509,29 @@ pub fn handle_removal_errors(
 ) {
     for error in removal_errors {
         match error {
-            RemovalError::UnknownDate(date, vehicle_journey_idx) => {
+            RemovalError::UnknownDate(date, vehicle_journey_idx, real_time_validity) => {
                 let vehicle_journey_name = model.vehicle_journey_name(&vehicle_journey_idx);
                 error!(
-                    "Trying to remove the vehicle journey {} on day {},  \
+                    "Trying to remove the vehicle journey {}, {:?} on day {},  \
                         but this day is not allowed in the data.  \
                         Allowed dates are between {} and {}",
-                    vehicle_journey_name, date, start_date, end_date,
+                    vehicle_journey_name, real_time_validity, date, start_date, end_date,
                 );
             }
-            RemovalError::UnknownVehicleJourney(vehicle_journey_idx) => {
+            RemovalError::UnknownVehicleJourney(vehicle_journey_idx, real_time_validity) => {
                 let vehicle_journey_name = model.vehicle_journey_name(&vehicle_journey_idx);
                 error!(
-                    "Trying to remove the vehicle journey {},  \
+                    "Trying to remove the vehicle journey {} {:?},  \
                         but this vehicle journey is unknown",
-                    vehicle_journey_name,
+                    vehicle_journey_name, real_time_validity
                 );
             }
-            RemovalError::DateInvalidForVehicleJourney(date, vehicle_journey_idx) => {
+            RemovalError::DateInvalidForVehicleJourney(date, vehicle_journey_idx, real_time_validity) => {
                 let vehicle_journey_name = model.vehicle_journey_name(&vehicle_journey_idx);
                 error!(
-                    "Trying to remove the vehicle journey {} on day {},  \
+                    "Trying to remove the vehicle journey {} {:?} on day {},  \
                         but this vehicle journeys does not exists on this day. ",
-                    vehicle_journey_name, date,
+                    vehicle_journey_name, real_time_validity, date,
                 );
             }
         }

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -164,7 +164,8 @@ where
         trip: &Self::Trip,
         position: &Self::Position,
     ) -> Option<(SecondsSinceDatasetUTCStart, Load)> {
-        self.timetables.board_time_of(trip, position)
+        self.timetables
+            .board_time_of(trip, position, &self.calendar)
     }
 
     fn debark_time_of(
@@ -172,7 +173,8 @@ where
         trip: &Self::Trip,
         position: &Self::Position,
     ) -> Option<(SecondsSinceDatasetUTCStart, Load)> {
-        self.timetables.debark_time_of(trip, position)
+        self.timetables
+            .debark_time_of(trip, position, &self.calendar)
     }
 
     fn arrival_time_of(
@@ -180,7 +182,8 @@ where
         trip: &Self::Trip,
         position: &Self::Position,
     ) -> (SecondsSinceDatasetUTCStart, Load) {
-        self.timetables.arrival_time_of(trip, position)
+        self.timetables
+            .arrival_time_of(trip, position, &self.calendar)
     }
 
     fn departure_time_of(
@@ -188,7 +191,8 @@ where
         trip: &Self::Trip,
         position: &Self::Position,
     ) -> (SecondsSinceDatasetUTCStart, Load) {
-        self.timetables.departure_time_of(trip, position)
+        self.timetables
+            .departure_time_of(trip, position, &self.calendar)
     }
 
     fn transfer_from_to_stop(&self, transfer: &Self::Transfer) -> (Self::Stop, Self::Stop) {
@@ -213,8 +217,14 @@ where
         position: &Self::Position,
         real_time_level: &RealTimeLevel,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)> {
-        self.timetables
-            .earliest_trip_to_board_at(waiting_time, mission, position, real_time_level)
+        self.timetables.earliest_trip_to_board_at(
+            waiting_time,
+            mission,
+            position,
+            real_time_level,
+            &self.calendar,
+            &self.days_patterns,
+        )
     }
 
     fn earliest_filtered_trip_to_board_at<Filter>(
@@ -234,6 +244,8 @@ where
             position,
             real_time_level,
             filter,
+            &self.calendar,
+            &self.days_patterns,
         )
     }
 
@@ -244,8 +256,14 @@ where
         position: &Self::Position,
         real_time_level: &RealTimeLevel,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)> {
-        self.timetables
-            .latest_trip_that_debark_at(waiting_time, mission, position, real_time_level)
+        self.timetables.latest_trip_that_debark_at(
+            waiting_time,
+            mission,
+            position,
+            real_time_level,
+            &self.calendar,
+            &self.days_patterns,
+        )
     }
 
     fn latest_filtered_trip_that_debark_at<Filter>(
@@ -265,6 +283,8 @@ where
             position,
             real_time_level,
             filter,
+            &self.calendar,
+            &self.days_patterns,
         )
     }
 
@@ -272,7 +292,7 @@ where
         &self,
         seconds: &crate::time::SecondsSinceDatasetUTCStart,
     ) -> chrono::NaiveDateTime {
-        self.timetables.calendar().to_naive_datetime(seconds)
+        self.calendar.to_naive_datetime(seconds)
     }
 
     fn vehicle_journey_idx(&self, trip: &Self::Trip) -> VehicleJourneyIdx {
@@ -288,7 +308,8 @@ where
     }
 
     fn day_of(&self, trip: &Self::Trip) -> chrono::NaiveDate {
-        self.timetables.day_of(trip)
+        let day = self.timetables.day_of(trip);
+        self.calendar.to_naive_date(&day)
     }
 
     fn is_same_stop(&self, stop_a: &Self::Stop, stop_b: &Self::Stop) -> bool {
@@ -296,7 +317,7 @@ where
     }
 
     fn calendar(&self) -> &Calendar {
-        self.timetables.calendar()
+        &self.calendar
     }
 
     fn stop_point_idx_to_stop(&self, stop_point_idx: &StopPointIdx) -> Option<Self::Stop> {
@@ -366,7 +387,8 @@ where
         mission: &Self::Mission,
         real_time_level: &RealTimeLevel,
     ) -> Self::TripsOfMission {
-        self.timetables.trips_of(mission, real_time_level)
+        self.timetables
+            .trips_of(mission, real_time_level, &self.days_patterns)
     }
 }
 

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -526,7 +526,11 @@ pub fn handle_removal_errors(
                     vehicle_journey_name, real_time_validity
                 );
             }
-            RemovalError::DateInvalidForVehicleJourney(date, vehicle_journey_idx, real_time_validity) => {
+            RemovalError::DateInvalidForVehicleJourney(
+                date,
+                vehicle_journey_idx,
+                real_time_validity,
+            ) => {
                 let vehicle_journey_name = model.vehicle_journey_name(&vehicle_journey_idx);
                 error!(
                     "Trying to remove the vehicle journey {} {:?} on day {},  \

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -108,6 +108,7 @@ pub trait Data: TransitTypes {
         waiting_time: &SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>;
 
     fn earliest_filtered_trip_to_board_at<Filter>(
@@ -115,6 +116,7 @@ pub trait Data: TransitTypes {
         waiting_time: &SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
         filter: Filter,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>
     where
@@ -125,6 +127,7 @@ pub trait Data: TransitTypes {
         waiting_time: &crate::time::SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>;
 
     fn latest_filtered_trip_that_debark_at<Filter>(
@@ -132,6 +135,7 @@ pub trait Data: TransitTypes {
         waiting_time: &crate::time::SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
         filter: Filter,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>
     where

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -229,7 +229,6 @@ pub trait DataIO {
         base_model: &BaseModel,
         loads_data: &LoadsData,
         default_transfer_duration: PositiveDuration,
-        restrict_calendar: Option<(NaiveDate, NaiveDate)>,
     ) -> Self;
 }
 

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -1,9 +1,4 @@
-use crate::{
-    loads_data::{Load, LoadsData},
-    models::{base_model::BaseModel, StopPointIdx, TransferIdx, VehicleJourneyIdx},
-    time::{PositiveDuration, SecondsSinceDatasetUTCStart, SecondsSinceTimezonedDayStart},
-    timetables::{FlowDirection, InsertionError, RemovalError},
-};
+use crate::{loads_data::{Load, LoadsData}, models::{base_model::BaseModel, StopPointIdx, TransferIdx, VehicleJourneyIdx}, time::{PositiveDuration, SecondsSinceDatasetUTCStart, SecondsSinceTimezonedDayStart}, timetables::{FlowDirection, InsertionError, RealTimeValidity, RemovalError}};
 use chrono::{NaiveDate, NaiveDateTime};
 pub use typed_index_collection::Idx;
 
@@ -179,14 +174,13 @@ pub enum RealTimeLevel {
 }
 
 pub trait DataUpdate {
-    fn remove_vehicle(
+    fn remove(
         &mut self,
         vehicle_journey_idx: &VehicleJourneyIdx,
         date: &NaiveDate,
-        real_time_level: RealTimeLevel,
     ) -> Result<(), RemovalError>;
 
-    fn add_real_time_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
+    fn insert<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
         &mut self,
         stops: Stops,
         flows: Flows,
@@ -204,7 +198,8 @@ pub trait DataUpdate {
         BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
         DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone;
 
-    fn modify_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
+
+    fn modify<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
         &mut self,
         stops: Stops,
         flows: Flows,
@@ -213,15 +208,15 @@ pub trait DataUpdate {
         loads_data: &LoadsData,
         valid_dates: Dates,
         timezone: &chrono_tz::Tz,
-        vehicle_journey_idx: VehicleJourneyIdx,
-        real_time_level: &RealTimeLevel,
-    ) -> (Vec<RemovalError>, Vec<InsertionError>)
+        vehicle_journey_idx: &VehicleJourneyIdx,
+    ) -> Vec<InsertionError>
     where
         Stops: Iterator<Item = StopPointIdx> + ExactSizeIterator + Clone,
         Flows: Iterator<Item = FlowDirection> + ExactSizeIterator + Clone,
         Dates: Iterator<Item = &'date chrono::NaiveDate> + Clone,
         BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
         DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone;
+
 }
 
 pub trait DataIO {

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -168,11 +168,18 @@ pub trait Data: TransitTypes {
     fn mission_id(&self, mission: &Self::Mission) -> usize;
 }
 
+#[derive(Debug, Clone)]
+pub enum RealTimeLevel {
+    Base,
+    RealTime,
+}
+
 pub trait DataUpdate {
     fn remove_vehicle(
         &mut self,
         vehicle_journey_idx: &VehicleJourneyIdx,
         date: &NaiveDate,
+        real_time_level: &RealTimeLevel,
     ) -> Result<(), RemovalError>;
 
     fn add_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
@@ -203,6 +210,7 @@ pub trait DataUpdate {
         valid_dates: Dates,
         timezone: &chrono_tz::Tz,
         vehicle_journey_idx: VehicleJourneyIdx,
+        real_time_level: &RealTimeLevel,
     ) -> (Vec<RemovalError>, Vec<InsertionError>)
     where
         Stops: Iterator<Item = StopPointIdx> + ExactSizeIterator + Clone,
@@ -210,15 +218,6 @@ pub trait DataUpdate {
         Dates: Iterator<Item = &'date chrono::NaiveDate> + Clone,
         BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
         DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone;
-
-    fn start_date(&self) -> &NaiveDate;
-    fn end_date(&self) -> &NaiveDate;
-
-    fn set_start_end_date(
-        &mut self,
-        start_date: &NaiveDate,
-        end_date: &NaiveDate,
-    ) -> (Vec<NaiveDate>, Vec<NaiveDate>);
 }
 
 pub trait DataIO {

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -1,4 +1,9 @@
-use crate::{loads_data::{Load, LoadsData}, models::{base_model::BaseModel, StopPointIdx, TransferIdx, VehicleJourneyIdx}, time::{PositiveDuration, SecondsSinceDatasetUTCStart, SecondsSinceTimezonedDayStart}, timetables::{FlowDirection, InsertionError, ModifyError, RemovalError}};
+use crate::{
+    loads_data::{Load, LoadsData},
+    models::{base_model::BaseModel, StopPointIdx, TransferIdx, VehicleJourneyIdx},
+    time::{PositiveDuration, SecondsSinceDatasetUTCStart, SecondsSinceTimezonedDayStart},
+    timetables::{FlowDirection, InsertionError, ModifyError, RemovalError},
+};
 use chrono::{NaiveDate, NaiveDateTime};
 pub use typed_index_collection::Idx;
 
@@ -198,7 +203,6 @@ pub trait DataUpdate {
         BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
         DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone;
 
-
     fn modify_real_time_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
         &mut self,
         stops: Stops,
@@ -216,7 +220,6 @@ pub trait DataUpdate {
         Dates: Iterator<Item = &'date chrono::NaiveDate> + Clone,
         BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
         DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone;
-
 }
 
 pub trait DataIO {
@@ -261,7 +264,11 @@ where
     /// Iterator for all `Trip`s belonging to a `Mission`.
     type TripsOfMission: Iterator<Item = Self::Trip>;
     /// Returns all `Trip`s belonging to `mission`
-    fn trips_of(&'a self, mission: &Self::Mission, real_time_level : &RealTimeLevel) -> Self::TripsOfMission;
+    fn trips_of(
+        &'a self,
+        mission: &Self::Mission,
+        real_time_level: &RealTimeLevel,
+    ) -> Self::TripsOfMission;
 }
 
 pub trait DataWithIters: Data + for<'a> DataIters<'a> {}

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -179,7 +179,7 @@ pub trait DataUpdate {
         &mut self,
         vehicle_journey_idx: &VehicleJourneyIdx,
         date: &NaiveDate,
-        real_time_level : RealTimeLevel,
+        real_time_level: RealTimeLevel,
     ) -> Result<(), RemovalError>;
 
     fn add_real_time_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
@@ -268,11 +268,9 @@ where
 
 pub trait DataWithIters: Data + for<'a> DataIters<'a> {}
 
-
-
 #[derive(Debug)]
 pub struct RealTimeLevelError {
-    incorrect_input : String,
+    incorrect_input: String,
 }
 impl std::fmt::Display for RealTimeLevelError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -290,9 +288,9 @@ impl std::str::FromStr for RealTimeLevel {
         match s {
             "base" => Ok(RealTimeLevel::Base),
             "real_time" => Ok(RealTimeLevel::RealTime),
-            _ => Err(RealTimeLevelError{
-                incorrect_input : s.to_string()
-            })
+            _ => Err(RealTimeLevelError {
+                incorrect_input: s.to_string(),
+            }),
         }
     }
 }
@@ -314,8 +312,7 @@ impl serde::Serialize for RealTimeLevel {
     where
         S: ::serde::Serializer,
     {
-        let str = 
-        match self {
+        let str = match self {
             RealTimeLevel::Base => "base",
             RealTimeLevel::RealTime => "real_time",
         };

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -179,10 +179,10 @@ pub trait DataUpdate {
         &mut self,
         vehicle_journey_idx: &VehicleJourneyIdx,
         date: &NaiveDate,
-        real_time_level: &RealTimeLevel,
+        real_time_level : RealTimeLevel,
     ) -> Result<(), RemovalError>;
 
-    fn add_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
+    fn add_real_time_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
         &mut self,
         stops: Stops,
         flows: Flows,

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -267,3 +267,58 @@ where
 }
 
 pub trait DataWithIters: Data + for<'a> DataIters<'a> {}
+
+
+
+#[derive(Debug)]
+pub struct RealTimeLevelError {
+    incorrect_input : String,
+}
+impl std::fmt::Display for RealTimeLevelError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Unable to parse {} as a real time level. Valid values are : base, real_time",
+            self.incorrect_input
+        )
+    }
+}
+
+impl std::str::FromStr for RealTimeLevel {
+    type Err = RealTimeLevelError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "base" => Ok(RealTimeLevel::Base),
+            "real_time" => Ok(RealTimeLevel::RealTime),
+            _ => Err(RealTimeLevelError{
+                incorrect_input : s.to_string()
+            })
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for RealTimeLevel {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+
+        use std::str::FromStr;
+        Self::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl serde::Serialize for RealTimeLevel {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ::serde::Serializer,
+    {
+        let str = 
+        match self {
+            RealTimeLevel::Base => "base",
+            RealTimeLevel::RealTime => "real_time",
+        };
+        serializer.serialize_str(str)
+    }
+}

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -1,4 +1,7 @@
-use crate::{loads_data::{Load, LoadsData}, models::{base_model::BaseModel, StopPointIdx, TransferIdx, VehicleJourneyIdx}, time::{PositiveDuration, SecondsSinceDatasetUTCStart, SecondsSinceTimezonedDayStart}, timetables::{FlowDirection, InsertionError, RealTimeValidity, RemovalError}};
+use crate::{loads_data::{Load, LoadsData}, 
+models::{base_model::BaseModel, StopPointIdx, TransferIdx, VehicleJourneyIdx}, 
+time::{PositiveDuration, SecondsSinceDatasetUTCStart, SecondsSinceTimezonedDayStart}, 
+timetables::{FlowDirection, InsertionError,  RemovalError}};
 use chrono::{NaiveDate, NaiveDateTime};
 pub use typed_index_collection::Idx;
 

--- a/src/transit_data/data_update.rs
+++ b/src/transit_data/data_update.rs
@@ -146,9 +146,7 @@ where
             let day = self
                 .calendar
                 .date_to_days_since_start(date)
-                .ok_or_else(|| {
-                    ModifyError::UnknownDate(date.clone(), vehicle_journey_idx.clone())
-                })?;
+                .ok_or_else(|| ModifyError::UnknownDate(*date, vehicle_journey_idx.clone()))?;
 
             if !self.vehicle_journey_to_timetable.real_time_vehicle_exists(
                 vehicle_journey_idx,
@@ -270,9 +268,7 @@ where
             let day = self
                 .calendar
                 .date_to_days_since_start(date)
-                .ok_or_else(|| {
-                    InsertionError::InvalidDate(date.clone(), vehicle_journey_idx.clone())
-                })?;
+                .ok_or_else(|| InsertionError::InvalidDate(*date, vehicle_journey_idx.clone()))?;
 
             if self.vehicle_journey_to_timetable.real_time_vehicle_exists(
                 &vehicle_journey_idx,

--- a/src/transit_data/data_update.rs
+++ b/src/transit_data/data_update.rs
@@ -58,13 +58,20 @@ where
         &mut self,
         vehicle_journey_idx: &VehicleJourneyIdx,
         date: &chrono::NaiveDate,
-        real_time_level: &RealTimeLevel,
+        real_time_level : RealTimeLevel,
     ) -> Result<(), RemovalError> {
+        let real_time_validity = match real_time_level {
+            RealTimeLevel::Base => RealTimeValidity::BaseAndRealTime,
+            RealTimeLevel::RealTime => RealTimeValidity::RealTimeOnly,
+        };
         self.timetables
-            .remove(date, vehicle_journey_idx, real_time_level)
+            .remove(date, vehicle_journey_idx, &real_time_validity)
+
     }
 
-    fn add_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
+ 
+
+    fn add_real_time_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
         &mut self,
         stop_points: Stops,
         flows: Flows,
@@ -118,7 +125,12 @@ where
         let mut insertion_errors = Vec::new();
 
         for date in valid_dates.clone() {
-            let removal_result = self.remove_vehicle(&vehicle_journey_idx, date, real_time_level);
+            let real_time_validity_to_remove = match real_time_level {
+                RealTimeLevel::Base => RealTimeValidity::BaseAndRealTime,
+                RealTimeLevel::RealTime => RealTimeValidity::RealTimeOnly,
+            };
+            let removal_result = self.timetables
+                    .remove(date, &vehicle_journey_idx, &real_time_validity_to_remove);
             match removal_result {
                 Ok(()) => {
                     let errors = self.add_vehicle_inner(
@@ -194,4 +206,6 @@ where
         errors.extend(insertion_errors);
         errors
     }
+
+
 }

--- a/src/transit_data/data_update.rs
+++ b/src/transit_data/data_update.rs
@@ -34,7 +34,6 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use std::fmt::Debug;
 
 use crate::{loads_data::LoadsData, models::{StopPointIdx, VehicleJourneyIdx}, timetables::{InsertionError, ModifyError, RemovalError}, transit_data::TransitData};
 
@@ -47,7 +46,7 @@ use super::data_interface::{self, RealTimeLevel};
 
 impl<Timetables> data_interface::DataUpdate for TransitData<Timetables>
 where
-    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> + Debug,
+    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> ,
 {
     fn remove_real_time_vehicle(
         &mut self,
@@ -114,7 +113,7 @@ where
 
 impl<Timetables>  TransitData<Timetables>
 where
-    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> + Debug,
+    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> ,
 {
 
 
@@ -165,7 +164,7 @@ where
             let stop = self.timetables.stop_at(&position, mission);
             let stop_data = &mut self.stops_data[stop.idx];
             let position_in_timetables = &mut stop_data.position_in_timetables;
-            if ! position_in_timetables.contains(&(*mission, position)) {
+            if ! position_in_timetables.contains(&(mission.clone(), position.clone())) {
                 position_in_timetables.push((mission.clone(), position));
             }
         }

--- a/src/transit_data/data_update.rs
+++ b/src/transit_data/data_update.rs
@@ -39,7 +39,7 @@ use std::fmt::Debug;
 use crate::{
     loads_data::LoadsData,
     models::{StopPointIdx, VehicleJourneyIdx},
-    timetables::{InsertionError, RemovalError},
+    timetables::{InsertionError, RealTimeValidity, RemovalError},
     transit_data::TransitData,
 };
 
@@ -47,11 +47,8 @@ use crate::{
     time::SecondsSinceTimezonedDayStart,
     timetables::{FlowDirection, Timetables as TimetablesTrait, TimetablesIter},
 };
-use chrono::NaiveDate;
 
-use tracing::warn;
-
-use super::{data_interface, init::restrict_dates};
+use super::data_interface::{self, RealTimeLevel};
 
 impl<Timetables> data_interface::DataUpdate for TransitData<Timetables>
 where
@@ -61,15 +58,10 @@ where
         &mut self,
         vehicle_journey_idx: &VehicleJourneyIdx,
         date: &chrono::NaiveDate,
+        real_time_level: &RealTimeLevel,
     ) -> Result<(), RemovalError> {
-        if *date < self.start_date || *date > self.end_date {
-            Err(RemovalError::UnknownDate(
-                *date,
-                vehicle_journey_idx.clone(),
-            ))
-        } else {
-            self.timetables.remove(date, vehicle_journey_idx)
-        }
+        self.timetables
+            .remove(date, vehicle_journey_idx, real_time_level)
     }
 
     fn add_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
@@ -90,19 +82,91 @@ where
         BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
         DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
     {
-        let mut errors = Vec::new();
-        let start_date = self.start_date;
-        let end_date = self.end_date;
+        self.add_vehicle_inner(
+            stop_points,
+            flows,
+            board_times,
+            debark_times,
+            loads_data,
+            valid_dates,
+            timezone,
+            vehicle_journey_idx,
+            &RealTimeValidity::RealTimeOnly,
+        )
+    }
+
+    fn modify_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
+        &mut self,
+        stops: Stops,
+        flows: Flows,
+        board_times: BoardTimes,
+        debark_times: DebarkTimes,
+        loads_data: &LoadsData,
+        valid_dates: Dates,
+        timezone: &chrono_tz::Tz,
+        vehicle_journey_idx: VehicleJourneyIdx,
+        real_time_level: &RealTimeLevel,
+    ) -> (Vec<RemovalError>, Vec<InsertionError>)
+    where
+        Stops: Iterator<Item = StopPointIdx> + ExactSizeIterator + Clone,
+        Flows: Iterator<Item = FlowDirection> + ExactSizeIterator + Clone,
+        Dates: Iterator<Item = &'date chrono::NaiveDate> + Clone,
+        BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
+        DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
+    {
+        let mut removal_errors = Vec::new();
+        let mut insertion_errors = Vec::new();
+
         for date in valid_dates.clone() {
-            if *date < start_date || *date > end_date {
-                errors.push(InsertionError::InvalidDate(
-                    *date,
-                    vehicle_journey_idx.clone(),
-                ));
+            let removal_result = self.remove_vehicle(&vehicle_journey_idx, date, real_time_level);
+            match removal_result {
+                Ok(()) => {
+                    let errors = self.add_vehicle_inner(
+                        stops.clone(),
+                        flows.clone(),
+                        board_times.clone(),
+                        debark_times.clone(),
+                        loads_data,
+                        valid_dates.clone(),
+                        timezone,
+                        vehicle_journey_idx.clone(),
+                        &RealTimeValidity::RealTimeOnly,
+                    );
+                    insertion_errors.extend_from_slice(errors.as_slice());
+                }
+                Err(removal_error) => {
+                    removal_errors.push(removal_error);
+                }
             }
         }
+        (removal_errors, insertion_errors)
+    }
+}
 
-        let dates = valid_dates.filter(|&&date| date >= start_date && date <= end_date);
+impl<Timetables> TransitData<Timetables>
+where
+    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> + Debug,
+{
+    pub(super) fn add_vehicle_inner<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
+        &mut self,
+        stop_points: Stops,
+        flows: Flows,
+        board_times: BoardTimes,
+        debark_times: DebarkTimes,
+        loads_data: &LoadsData,
+        valid_dates: Dates,
+        timezone: &chrono_tz::Tz,
+        vehicle_journey_idx: VehicleJourneyIdx,
+        real_time_validity: &RealTimeValidity,
+    ) -> Vec<InsertionError>
+    where
+        Stops: Iterator<Item = StopPointIdx> + ExactSizeIterator + Clone,
+        Flows: Iterator<Item = FlowDirection> + ExactSizeIterator + Clone,
+        Dates: Iterator<Item = &'date chrono::NaiveDate> + Clone,
+        BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
+        DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
+    {
+        let mut errors = Vec::new();
 
         let stops = self.create_stops(stop_points).into_iter();
         let (missions, insertion_errors) = self.timetables.insert(
@@ -111,9 +175,10 @@ where
             board_times,
             debark_times,
             loads_data,
-            dates,
+            valid_dates,
             timezone,
             &vehicle_journey_idx,
+            real_time_validity,
         );
 
         for mission in missions.iter() {
@@ -128,136 +193,5 @@ where
 
         errors.extend(insertion_errors);
         errors
-    }
-
-    fn modify_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
-        &mut self,
-        stops: Stops,
-        flows: Flows,
-        board_times: BoardTimes,
-        debark_times: DebarkTimes,
-        loads_data: &LoadsData,
-        valid_dates: Dates,
-        timezone: &chrono_tz::Tz,
-        vehicle_journey_idx: VehicleJourneyIdx,
-    ) -> (Vec<RemovalError>, Vec<InsertionError>)
-    where
-        Stops: Iterator<Item = StopPointIdx> + ExactSizeIterator + Clone,
-        Flows: Iterator<Item = FlowDirection> + ExactSizeIterator + Clone,
-        Dates: Iterator<Item = &'date chrono::NaiveDate> + Clone,
-        BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
-        DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
-    {
-        let mut removal_errors = Vec::new();
-        let mut insertion_errors = Vec::new();
-
-        let start_date = self.start_date;
-        let end_date = self.end_date;
-        for date in valid_dates.clone() {
-            if *date < start_date || *date > end_date {
-                insertion_errors.push(InsertionError::InvalidDate(
-                    *date,
-                    vehicle_journey_idx.clone(),
-                ));
-            }
-        }
-
-        let dates = valid_dates.filter(|&&date| date >= start_date && date <= end_date);
-
-        for date in dates.clone() {
-            let removal_result = self.remove_vehicle(&vehicle_journey_idx, date);
-            match removal_result {
-                Ok(()) => {
-                    let errors = self.add_vehicle(
-                        stops.clone(),
-                        flows.clone(),
-                        board_times.clone(),
-                        debark_times.clone(),
-                        loads_data,
-                        dates.clone(),
-                        timezone,
-                        vehicle_journey_idx.clone(),
-                    );
-                    insertion_errors.extend_from_slice(errors.as_slice());
-                }
-                Err(removal_error) => {
-                    removal_errors.push(removal_error);
-                }
-            }
-        }
-        (removal_errors, insertion_errors)
-    }
-
-    fn set_start_end_date(
-        &mut self,
-        restricted_start_date: &NaiveDate,
-        restricted_end_date: &NaiveDate,
-    ) -> (Vec<NaiveDate>, Vec<NaiveDate>) {
-        let old_start_date = self.start_date;
-        let old_end_date = self.end_date;
-        let calendar = self.timetables.calendar();
-        let calendar_start_date = calendar.first_date();
-        let calendar_end_date = calendar.last_date();
-        let (start_date, end_date) = restrict_dates(
-            calendar_start_date,
-            calendar_end_date,
-            restricted_start_date,
-            restricted_end_date,
-        );
-
-        let mut removed_days = Vec::new();
-        if old_start_date <= old_end_date {
-            let num_days = (old_end_date - old_start_date).num_days();
-            if num_days >= 0 {
-                for day_offset in 0..=num_days {
-                    let date = old_start_date + chrono::Duration::days(day_offset);
-                    if date < start_date || date > end_date {
-                        removed_days.push(date);
-                        self.remove_all_vehicles_on_date(&date);
-                    }
-                }
-            }
-        }
-        let mut added_days = Vec::new();
-        if start_date <= end_date {
-            let num_days = (end_date - start_date).num_days();
-            if num_days >= 0 {
-                for day_offset in 0..=num_days {
-                    let date = start_date + chrono::Duration::days(day_offset);
-                    if date < old_start_date || date > old_end_date {
-                        added_days.push(date);
-                    }
-                }
-            }
-        }
-
-        self.start_date = start_date;
-        self.end_date = end_date;
-        (removed_days, added_days)
-    }
-
-    fn start_date(&self) -> &NaiveDate {
-        &self.start_date
-    }
-
-    fn end_date(&self) -> &NaiveDate {
-        &self.end_date
-    }
-}
-
-impl<Timetables> TransitData<Timetables>
-where
-    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> + Debug,
-{
-    fn remove_all_vehicles_on_date(&mut self, date: &NaiveDate) {
-        if *date < self.start_date || *date > self.end_date {
-            warn!(
-                "Trying to remove all vehicles on day {}, which is invalid for the data. \
-                    Allowed dates are between {} and {}",
-                date, self.start_date, self.end_date
-            );
-            return;
-        }
-        self.timetables.remove_all_vehicle_on_day(date)
     }
 }

--- a/src/transit_data/data_update.rs
+++ b/src/transit_data/data_update.rs
@@ -58,7 +58,7 @@ where
         &mut self,
         vehicle_journey_idx: &VehicleJourneyIdx,
         date: &chrono::NaiveDate,
-        real_time_level : RealTimeLevel,
+        real_time_level: RealTimeLevel,
     ) -> Result<(), RemovalError> {
         let real_time_validity = match real_time_level {
             RealTimeLevel::Base => RealTimeValidity::BaseAndRealTime,
@@ -66,10 +66,7 @@ where
         };
         self.timetables
             .remove(date, vehicle_journey_idx, &real_time_validity)
-
     }
-
- 
 
     fn add_real_time_vehicle<'date, Stops, Flows, Dates, BoardTimes, DebarkTimes>(
         &mut self,
@@ -129,7 +126,8 @@ where
                 RealTimeLevel::Base => RealTimeValidity::BaseAndRealTime,
                 RealTimeLevel::RealTime => RealTimeValidity::RealTimeOnly,
             };
-            let removal_result = self.timetables
+            let removal_result =
+                self.timetables
                     .remove(date, &vehicle_journey_idx, &real_time_validity_to_remove);
             match removal_result {
                 Ok(()) => {
@@ -206,6 +204,4 @@ where
         errors.extend(insertion_errors);
         errors
     }
-
-
 }

--- a/src/transit_data/init.rs
+++ b/src/transit_data/init.rs
@@ -78,7 +78,7 @@ where
         let mut data = Self {
             stop_point_idx_to_stop: std::collections::HashMap::new(),
             stops_data: Vec::with_capacity(nb_of_stop_points),
-            timetables: Timetables::new(start_date, end_date),
+            timetables: Timetables::new(),
             transfers_data: Vec::with_capacity(nb_transfers),
             vehicle_journey_to_timetable: VehicleJourneyToTimetable::new(),
             calendar,

--- a/src/transit_data/init.rs
+++ b/src/transit_data/init.rs
@@ -40,6 +40,8 @@ use crate::{
         base_model::BaseModel, real_time_model::RealTimeModel, ModelRefs, StopPointIdx,
         TransferIdx, VehicleJourneyIdx,
     },
+    time::{days_patterns::DaysPatterns, Calendar},
+    timetables::day_to_timetable::VehicleJourneyToTimetable,
     transit_data::{Stop, TransitData},
     RealTimeLevel,
 };
@@ -70,12 +72,17 @@ where
         let (start_date, end_date) = base_model
             .calculate_validity_period()
             .expect("Unable to calculate a validity period.");
+        let calendar = Calendar::new(start_date, end_date);
+        let nb_of_days = calendar.nb_of_days();
 
         let mut data = Self {
             stop_point_idx_to_stop: std::collections::HashMap::new(),
             stops_data: Vec::with_capacity(nb_of_stop_points),
             timetables: Timetables::new(start_date, end_date),
             transfers_data: Vec::with_capacity(nb_transfers),
+            vehicle_journey_to_timetable: VehicleJourneyToTimetable::new(),
+            calendar,
+            days_patterns: DaysPatterns::new(usize::from(nb_of_days)),
         };
 
         data.init(base_model, loads_data, default_transfer_duration);

--- a/src/transit_data/init.rs
+++ b/src/transit_data/init.rs
@@ -34,15 +34,15 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-
-use crate::{RealTimeLevel, loads_data::LoadsData, models::{
-        base_model::BaseModel, 
-        real_time_model::RealTimeModel, 
-        ModelRefs, 
-        StopPointIdx,
-        TransferIdx, 
-        VehicleJourneyIdx,
-    }, transit_data::{Stop, TransitData}};
+use crate::{
+    loads_data::LoadsData,
+    models::{
+        base_model::BaseModel, real_time_model::RealTimeModel, ModelRefs, StopPointIdx,
+        TransferIdx, VehicleJourneyIdx,
+    },
+    transit_data::{Stop, TransitData},
+    RealTimeLevel,
+};
 
 use crate::{
     time::{PositiveDuration, SecondsSinceTimezonedDayStart},
@@ -242,7 +242,6 @@ where
                 &err,
             );
         }
-
 
         Ok(())
     }

--- a/src/transit_data/init.rs
+++ b/src/transit_data/init.rs
@@ -43,15 +43,13 @@ use crate::{
         TransferIdx, VehicleJourneyIdx,
     },
     timetables::RealTimeValidity,
-    transit_data::{data_interface::RealTimeLevel, Stop, TransitData},
-    DataUpdate,
+    transit_data::{Stop, TransitData},
 };
 
 use crate::{
     time::{PositiveDuration, SecondsSinceTimezonedDayStart},
     timetables::{FlowDirection, Timetables as TimetablesTrait, TimetablesIter},
 };
-use chrono::NaiveDate;
 use transit_model::objects::{StopTime, VehicleJourney};
 use typed_index_collection::Idx;
 
@@ -67,7 +65,6 @@ where
         base_model: &BaseModel,
         loads_data: &LoadsData,
         default_transfer_duration: PositiveDuration,
-        restrict_calendar: Option<(NaiveDate, NaiveDate)>,
     ) -> Self {
         let nb_of_stop_points = base_model.stop_points.len();
         let nb_transfers = base_model.transfers.len();
@@ -241,8 +238,8 @@ where
         use crate::transit_data::data_interface::Data;
         handle_insertion_errors(
             &model,
-            &self.calendar().first_date(),
-            &self.calendar().last_date(),
+            self.calendar().first_date(),
+            self.calendar().last_date(),
             &insertion_errors,
         );
 
@@ -417,34 +414,4 @@ pub fn debark_timezoned_times(
     }
 
     Ok(result)
-}
-
-pub(super) fn restrict_dates(
-    calendar_start_date: &NaiveDate,
-    calendar_end_date: &NaiveDate,
-    restricted_start_date: &NaiveDate,
-    restricted_end_date: &NaiveDate,
-) -> (NaiveDate, NaiveDate) {
-    let start_date = if restricted_start_date < calendar_start_date {
-        warn!(
-            "Trying to restrict the start date to {} but the calendar starts on {}.\
-             I'll ignore the restricted start date.",
-            restricted_start_date, calendar_start_date
-        );
-        calendar_start_date
-    } else {
-        restricted_start_date
-    };
-    let end_date = if restricted_end_date > calendar_end_date {
-        warn!(
-            "Trying to restrict the end date to {} but the calendar ends on {}.\
-        I'll ignore the restricted start date.",
-            restricted_end_date, calendar_end_date
-        );
-        calendar_end_date
-    } else {
-        restricted_end_date
-    };
-
-    (*start_date, *end_date)
 }

--- a/src/transit_data/init.rs
+++ b/src/transit_data/init.rs
@@ -34,7 +34,6 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use std::fmt::Debug;
 
 use crate::{RealTimeLevel, loads_data::LoadsData, models::{
         base_model::BaseModel, 
@@ -58,7 +57,7 @@ use super::{handle_insertion_error, Transfer, TransferData, TransferDurations};
 
 impl<Timetables> TransitData<Timetables>
 where
-    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a> + Debug,
+    Timetables: TimetablesTrait + for<'a> TimetablesIter<'a>,
 {
     pub fn _new(
         base_model: &BaseModel,

--- a/src/transit_data/init.rs
+++ b/src/transit_data/init.rs
@@ -54,7 +54,7 @@ use typed_index_collection::Idx;
 
 use tracing::{info, warn};
 
-use super::{handle_insertion_errors, Transfer, TransferData, TransferDurations};
+use super::{handle_insertion_error, Transfer, TransferData, TransferDurations};
 
 impl<Timetables> TransitData<Timetables>
 where
@@ -216,7 +216,7 @@ where
 
         let vehicle_journey_idx = VehicleJourneyIdx::Base(vehicle_journey_idx);
 
-        let insertion_errors = self.insert_inner(
+        let insert_result = self.insert_inner(
             stop_points,
             flows.into_iter(),
             board_times.into_iter(),
@@ -235,12 +235,15 @@ where
         };
 
         use crate::transit_data::data_interface::Data;
-        handle_insertion_errors(
-            &model,
-            self.calendar().first_date(),
-            self.calendar().last_date(),
-            &insertion_errors,
-        );
+        if let Err(err) = insert_result {
+            handle_insertion_error(
+                &model,
+                self.calendar().first_date(),
+                self.calendar().last_date(),
+                &err,
+            );
+        }
+
 
         Ok(())
     }

--- a/src/transit_data/init.rs
+++ b/src/transit_data/init.rs
@@ -43,7 +43,7 @@ use crate::{RealTimeLevel, loads_data::LoadsData, models::{
         StopPointIdx,
         TransferIdx, 
         VehicleJourneyIdx,
-    }, timetables::RealTimeValidity, transit_data::{Stop, TransitData}, transit_data::data_interface::DataUpdate};
+    }, transit_data::{Stop, TransitData}};
 
 use crate::{
     time::{PositiveDuration, SecondsSinceTimezonedDayStart},

--- a/src/transit_data/init.rs
+++ b/src/transit_data/init.rs
@@ -36,15 +36,14 @@
 
 use std::fmt::Debug;
 
-use crate::{
-    loads_data::LoadsData,
-    models::{
-        base_model::BaseModel, real_time_model::RealTimeModel, ModelRefs, StopPointIdx,
-        TransferIdx, VehicleJourneyIdx,
-    },
-    timetables::RealTimeValidity,
-    transit_data::{Stop, TransitData},
-};
+use crate::{RealTimeLevel, loads_data::LoadsData, models::{
+        base_model::BaseModel, 
+        real_time_model::RealTimeModel, 
+        ModelRefs, 
+        StopPointIdx,
+        TransferIdx, 
+        VehicleJourneyIdx,
+    }, timetables::RealTimeValidity, transit_data::{Stop, TransitData}, transit_data::data_interface::DataUpdate};
 
 use crate::{
     time::{PositiveDuration, SecondsSinceTimezonedDayStart},
@@ -217,7 +216,7 @@ where
 
         let vehicle_journey_idx = VehicleJourneyIdx::Base(vehicle_journey_idx);
 
-        let insertion_errors = self.add_vehicle_inner(
+        let insertion_errors = self.insert_inner(
             stop_points,
             flows.into_iter(),
             board_times.into_iter(),
@@ -226,7 +225,7 @@ where
             dates,
             &timezone,
             vehicle_journey_idx,
-            &RealTimeValidity::BaseAndRealTime,
+            RealTimeLevel::Base,
         );
 
         let real_time_model = RealTimeModel::new();

--- a/src/transit_data_filtered.rs
+++ b/src/transit_data_filtered.rs
@@ -426,7 +426,11 @@ where
 
     type TripsOfMission = Data::TripsOfMission;
 
-    fn trips_of(&'a self, mission: &Self::Mission, real_time_level : &RealTimeLevel) -> Self::TripsOfMission {
+    fn trips_of(
+        &'a self,
+        mission: &Self::Mission,
+        real_time_level: &RealTimeLevel,
+    ) -> Self::TripsOfMission {
         self.transit_data.trips_of(mission, real_time_level)
     }
 }

--- a/src/transit_data_filtered.rs
+++ b/src/transit_data_filtered.rs
@@ -39,7 +39,7 @@ use crate::{
     loads_data::Load,
     models::{ModelRefs, StopPointIdx, TransferIdx, VehicleJourneyIdx},
     time::{Calendar, PositiveDuration, SecondsSinceDatasetUTCStart},
-    DataWithIters,
+    DataWithIters, RealTimeLevel,
 };
 pub use transit_model::objects::{
     StopPoint, Time as TransitModelTime, Transfer as TransitModelTransfer, VehicleJourney,
@@ -246,6 +246,7 @@ where
         waiting_time: &crate::time::SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)> {
         let stop = self.stop_of(position, mission);
 
@@ -254,6 +255,7 @@ where
                 waiting_time,
                 mission,
                 position,
+                real_time_level,
                 |vehicle_journey_idx: &VehicleJourneyIdx| {
                     self.is_vehicle_journey_allowed(vehicle_journey_idx)
                 },
@@ -268,6 +270,7 @@ where
         waiting_time: &SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
         filter: Filter,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>
     where
@@ -279,6 +282,7 @@ where
                 waiting_time,
                 mission,
                 position,
+                real_time_level,
                 |vehicle_journey_idx: &VehicleJourneyIdx| {
                     self.is_vehicle_journey_allowed(vehicle_journey_idx)
                         && filter(vehicle_journey_idx)
@@ -294,6 +298,7 @@ where
         waiting_time: &crate::time::SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)> {
         let stop = self.stop_of(position, mission);
 
@@ -302,6 +307,7 @@ where
                 waiting_time,
                 mission,
                 position,
+                real_time_level,
                 |vehicle_journey_idx: &VehicleJourneyIdx| {
                     self.is_vehicle_journey_allowed(vehicle_journey_idx)
                 },
@@ -316,6 +322,7 @@ where
         waiting_time: &crate::time::SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
         position: &Self::Position,
+        real_time_level: &RealTimeLevel,
         filter: Filter,
     ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>
     where
@@ -328,6 +335,7 @@ where
                 waiting_time,
                 mission,
                 position,
+                real_time_level,
                 |vehicle_journey_idx: &VehicleJourneyIdx| {
                     self.is_vehicle_journey_allowed(vehicle_journey_idx)
                         && filter(vehicle_journey_idx)

--- a/src/transit_data_filtered.rs
+++ b/src/transit_data_filtered.rs
@@ -426,8 +426,8 @@ where
 
     type TripsOfMission = Data::TripsOfMission;
 
-    fn trips_of(&'a self, mission: &Self::Mission) -> Self::TripsOfMission {
-        self.transit_data.trips_of(mission)
+    fn trips_of(&'a self, mission: &Self::Mission, real_time_level : &RealTimeLevel) -> Self::TripsOfMission {
+        self.transit_data.trips_of(mission, real_time_level)
     }
 }
 

--- a/stop_areas/src/lib.rs
+++ b/stop_areas/src/lib.rs
@@ -41,7 +41,7 @@ use launch::{
         self,
         models::{base_model::BaseModel, real_time_model::RealTimeModel, ModelRefs},
         request::generic_request,
-        PeriodicSplitVjData, TransitData,
+        DailyData, PeriodicData, PeriodicSplitVjData, TransitData,
     },
     solver::Solver,
 };

--- a/stop_areas/src/lib.rs
+++ b/stop_areas/src/lib.rs
@@ -54,7 +54,6 @@ use std::{fs::File, io::BufReader, time::SystemTime};
 use failure::{bail, Error};
 
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -181,7 +180,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    Timetables: for<'a> TimetablesIter<'a> + Debug,
+    Timetables: for<'a> TimetablesIter<'a> ,
     Timetables::Mission: 'static,
     Timetables::Position: 'static,
 {
@@ -202,7 +201,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    Timetables: for<'a> TimetablesIter<'a> + Debug,
+    Timetables: for<'a> TimetablesIter<'a> ,
     Timetables::Mission: 'static,
     Timetables::Position: 'static,
 {

--- a/stop_areas/src/lib.rs
+++ b/stop_areas/src/lib.rs
@@ -41,7 +41,7 @@ use launch::{
         self,
         models::{base_model::BaseModel, real_time_model::RealTimeModel, ModelRefs},
         request::generic_request,
-        DailyData, PeriodicData, PeriodicSplitVjData, TransitData,
+        PeriodicSplitVjData, TransitData,
     },
     solver::Solver,
 };
@@ -168,8 +168,8 @@ pub fn read_config(config_file: &ConfigFile) -> Result<Config, Error> {
 
 pub fn launch(config: Config) -> Result<(BaseModel, Vec<loki::Response>), Error> {
     match config.launch_params.data_implem {
-        config::DataImplem::Periodic => config_launch::<PeriodicData>(config),
         config::DataImplem::PeriodicSplitVj => config_launch::<PeriodicSplitVjData>(config),
+        config::DataImplem::Periodic => config_launch::<PeriodicData>(config),
         config::DataImplem::Daily => config_launch::<DailyData>(config),
     }
 }

--- a/stop_areas/src/lib.rs
+++ b/stop_areas/src/lib.rs
@@ -180,7 +180,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    Timetables: for<'a> TimetablesIter<'a> ,
+    Timetables: for<'a> TimetablesIter<'a>,
     Timetables::Mission: 'static,
     Timetables::Position: 'static,
 {
@@ -201,7 +201,7 @@ where
         Position = generic_request::Position,
         Trip = generic_request::Trip,
     >,
-    Timetables: for<'a> TimetablesIter<'a> ,
+    Timetables: for<'a> TimetablesIter<'a>,
     Timetables::Mission: 'static,
     Timetables::Position: 'static,
 {


### PR DESCRIPTION
A Vehicle in a Timetable is now flagged as base and/or real_time. 
We are then able to find earliest_trip_to_board/lastest_trip_that_debark restricted on vehicle that are valid for Base/RealTime levels.