### PR TITLE
configure logger for tests

### DIFF
--- a/launch/Cargo.toml
+++ b/launch/Cargo.toml
@@ -17,7 +17,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 anyhow = "1"
-env_logger = "0.9.0"
 rstest = "0.11"
 
 [features]

--- a/launch/Cargo.toml
+++ b/launch/Cargo.toml
@@ -17,7 +17,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 anyhow = "1"
-rstest = "0.11"
+rstest = "0.12"
 
 [features]
 # enable the vehicle_loads feature on the loki lib

--- a/launch/src/logger.rs
+++ b/launch/src/logger.rs
@@ -1,7 +1,8 @@
 use crate::loki::tracing::level_filters::LevelFilter;
+use loki::tracing::dispatcher::DefaultGuard;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-pub fn init_logger() {
+pub fn init_logger() -> DefaultGuard {
     let default_level = LevelFilter::INFO;
     let rust_log =
         std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_| default_level.to_string());
@@ -17,5 +18,24 @@ pub fn init_logger() {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer())
         .with(env_filter_subscriber)
-        .init();
+        .set_default()
+}
+
+pub fn init_test_logger() -> DefaultGuard {
+    let default_level = LevelFilter::DEBUG;
+    let rust_log =
+        std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_| default_level.to_string());
+    let env_filter_subscriber = EnvFilter::try_new(rust_log).unwrap_or_else(|err| {
+        eprintln!(
+            "invalid {}, falling back to level '{}' - {}",
+            EnvFilter::DEFAULT_ENV,
+            default_level,
+            err,
+        );
+        EnvFilter::new(default_level.to_string())
+    });
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_test_writer())
+        .with(env_filter_subscriber)
+        .set_default()
 }

--- a/launch/src/logger.rs
+++ b/launch/src/logger.rs
@@ -2,6 +2,7 @@ use crate::loki::tracing::level_filters::LevelFilter;
 use loki::tracing::dispatcher::DefaultGuard;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
+#[must_use]
 pub fn init_logger() -> DefaultGuard {
     let default_level = LevelFilter::INFO;
     let rust_log =
@@ -21,6 +22,7 @@ pub fn init_logger() -> DefaultGuard {
         .set_default()
 }
 
+#[must_use]
 pub fn init_test_logger() -> DefaultGuard {
     let default_level = LevelFilter::DEBUG;
     let rust_log =

--- a/launch/tests/loads_test.rs
+++ b/launch/tests/loads_test.rs
@@ -81,7 +81,7 @@ fn test_loads_matin() -> Result<(), Error> {
     // The `soir` trip arrives later and has a high load, and thus should
     //  not be present.
 
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     let base_model = create_model();
 
@@ -115,7 +115,7 @@ fn test_loads_midi() -> Result<(), Error> {
     // We should obtain only one journey with the `midi` trip.
     // Indeed, `matin` cannot be boarded, and `soir` arrives
     // later than `midi` with a higher load
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     let base_model = create_model();
 
@@ -142,7 +142,7 @@ fn test_without_loads_matin() -> Result<(), Error> {
     // We do NOT use the loads as criteria.
     // We should obtain only one journey with the `matin` trip.
     // Indeed, `midi` and `soir` arrives later than `matin`.
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     let base_model = create_model();
 

--- a/launch/tests/routing_with_filters_test.rs
+++ b/launch/tests/routing_with_filters_test.rs
@@ -97,7 +97,7 @@ fn test_no_filter(
     #[case] data_implem: DataImplem,
     fixture_model: BaseModel,
 ) -> Result<(), Error> {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     let config = Config::new("2020-01-01T09:59:00", "A", "J");
     let config = Config {
@@ -137,7 +137,7 @@ fn test_filter_forbidden_stop_point(
     #[case] data_implem: DataImplem,
     fixture_model: BaseModel,
 ) -> Result<(), Error> {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     // With Filter : stop_point:C is forbidden
     let config = Config::new("2020-01-01T09:59:00", "A", "J");
@@ -180,7 +180,7 @@ fn test_filter_allowed_stop_point(
     #[case] data_implem: DataImplem,
     fixture_model: BaseModel,
 ) -> Result<(), Error> {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     // With Filter : stop_point:C is forbidden
     let config = Config::new("2020-01-01T09:59:00", "A", "J");
@@ -230,7 +230,7 @@ fn test_filter_forbidden_route(
     #[case] data_implem: DataImplem,
     fixture_model: BaseModel,
 ) -> Result<(), Error> {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     // With Filter : stop_point:C is forbidden
     let config = Config::new("2020-01-01T09:59:00", "A", "J");
@@ -272,7 +272,7 @@ fn test_filter_allowed_route(
     #[case] data_implem: DataImplem,
     fixture_model: BaseModel,
 ) -> Result<(), Error> {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     // With Filter : stop_point:C is forbidden
     let config = Config::new("2020-01-01T09:59:00", "A", "J");

--- a/launch/tests/simple_routing_test.rs
+++ b/launch/tests/simple_routing_test.rs
@@ -59,7 +59,7 @@ fn test_simple_routing(
     #[case] comparator_type: ComparatorType,
     #[case] data_implem: DataImplem,
 ) -> Result<(), Error> {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("toto", |vj_builder| {
@@ -120,7 +120,7 @@ fn test_routing_with_transfers(
     #[case] comparator_type: ComparatorType,
     #[case] data_implem: DataImplem,
 ) -> Result<(), Error> {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("toto", |vj_builder| {
@@ -223,7 +223,7 @@ fn test_routing_backward(
     #[case] comparator_type: ComparatorType,
     #[case] data_implem: DataImplem,
 ) -> Result<(), Error> {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("toto", |vj_builder| {
@@ -328,7 +328,7 @@ fn test_second_pass_forward(
     #[case] comparator_type: ComparatorType,
     #[case] data_implem: DataImplem,
 ) -> Result<(), Error> {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("toto", |vj_builder| {
@@ -404,8 +404,7 @@ fn test_second_pass_backward(
     #[case] comparator_type: ComparatorType,
     #[case] data_implem: DataImplem,
 ) -> Result<(), Error> {
-    utils::init_logger();
-
+    let _log_guard = launch::logger::init_test_logger();
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("toto", |vj_builder| {
             vj_builder

--- a/launch/tests/timezone_test.rs
+++ b/launch/tests/timezone_test.rs
@@ -54,7 +54,7 @@ use rstest::rstest;
 #[case(DataImplem::Daily)]
 #[case(DataImplem::PeriodicSplitVj)]
 fn test_daylight_saving_time_switch(#[case] data_implem: DataImplem) -> Result<(), Error> {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     // There is a daylight saving time switch in Europe/paris on 2020-10-25 :
     // - on 2020-10-24, "10:00:00" in Paris means "08:00:00" UTC
@@ -117,7 +117,7 @@ fn test_daylight_saving_time_switch(#[case] data_implem: DataImplem) -> Result<(
 fn test_trip_over_daylight_saving_time_switch(
     #[case] data_implem: DataImplem,
 ) -> Result<(), Error> {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     // There is a daylight saving time switch in Europe/paris on 2020-10-25 at 02:00:00
     let model = ModelBuilder::new("2020-10-23", "2020-10-30")
@@ -237,7 +237,7 @@ fn test_trip_over_daylight_saving_time_switch(
 #[case(DataImplem::Daily)]
 #[case(DataImplem::PeriodicSplitVj)]
 fn test_paris_london(#[case] data_implem: DataImplem) -> Result<(), Error> {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     // There is a daylight saving time switch in Europe/Paris AND Europe/London on 2020-10-25 at 02:00:00
     let model = ModelBuilder::new("2020-10-01", "2020-10-30")
@@ -338,7 +338,7 @@ fn test_paris_london(#[case] data_implem: DataImplem) -> Result<(), Error> {
 #[case(DataImplem::Daily)]
 #[case(DataImplem::PeriodicSplitVj)]
 fn test_paris_new_york(#[case] data_implem: DataImplem) -> Result<(), Error> {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     // There is a daylight saving time switch in Europe/Paris  on 2020-10-25 at 02:00:00
     // But there is no switch in America/NewYork

--- a/launch/tests/update_data_test.rs
+++ b/launch/tests/update_data_test.rs
@@ -76,7 +76,7 @@ where
     T::Mission: 'static,
     T::Position: 'static,
 {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("first", |vj_builder| {
@@ -204,7 +204,7 @@ where
     T::Mission: 'static,
     T::Position: 'static,
 {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("first", |vj_builder| {
@@ -360,7 +360,7 @@ where
     T::Mission: 'static,
     T::Position: 'static,
 {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("first", |vj_builder| {
@@ -492,7 +492,7 @@ where
     T::Mission: 'static,
     T::Position: 'static,
 {
-    utils::init_logger();
+    let _log_guard = launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("first", |vj_builder| {

--- a/launch/tests/utils/mod.rs
+++ b/launch/tests/utils/mod.rs
@@ -38,7 +38,6 @@ pub mod disruption_builder;
 pub mod model_builder;
 
 use anyhow::{format_err, Error};
-use env_logger::Env;
 use launch::{
     config,
     config::launch_params::default_transfer_duration,
@@ -59,16 +58,6 @@ use loki::{
     DailyData, NaiveDateTime, PeriodicData, PeriodicSplitVjData, PositiveDuration, TransitData,
 };
 use model_builder::AsDateTime;
-
-pub fn init_logger() {
-    let _ = env_logger::Builder::from_env(
-        // use log level specified by RUST_LOG env var if set
-        //  and default to the "debug" level when RUST_LOG is not set
-        Env::default().default_filter_or("debug"),
-    )
-    .is_test(true)
-    .try_init();
-}
 
 pub struct Config<'a> {
     pub request_params: config::RequestParams,

--- a/random/src/main.rs
+++ b/random/src/main.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 use structopt::StructOpt;
 
 fn main() {
-    launch::logger::init_logger();
+    let _log_guard = launch::logger::init_logger();
     if let Err(err) = run() {
         eprintln!("{:?}", err);
         std::process::exit(1);

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -35,7 +35,7 @@ hostname = "0.3"
 
 [dev-dependencies]
 shiplift = "0.7" # docker API
-tempdir = "0.3"
+tempfile = "3"
 
 [build-dependencies]
 prost-build = "0.9"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -35,7 +35,7 @@
 // www.navitia.io
 
 fn main() {
-    launch::logger::init_logger();
+    let _log_guard = launch::logger::init_logger();
     if let Err(err) = loki_server::launch_server() {
         eprintln!("{:?}", err);
         std::process::exit(1);

--- a/server/tests/reload_test.rs
+++ b/server/tests/reload_test.rs
@@ -47,11 +47,6 @@ use lapin::{options::BasicPublishOptions, BasicProperties};
 use launch::loki::{chrono::Utc, tracing::info, NaiveDateTime, PositiveDuration};
 use shiplift::builder::PullOptionsBuilder;
 
-// TODO
-//  - launch rabbitmq docker from tests ?
-//  - add a "status" to the zmq endpoint, in order to determine when the data has been reloaded
-//  - design a small dataset with an obvious journey that can be queried/modified
-
 #[test]
 fn main() -> () {
     let _log_guard = launch::logger::init_test_logger();
@@ -67,11 +62,8 @@ fn main() -> () {
 async fn run() -> () {
     let start_test_datetime = Utc::now().naive_utc();
 
-    let working_dir = tempdir::TempDir::new("loki_reload_data_test").unwrap();
+    let working_dir = tempfile::tempdir().unwrap();
     let working_dir_path = working_dir.path();
-    // let working_dir_path = PathBuf::from_str("/tmp/test_loki/").unwrap();
-
-    println!("Coucou");
 
     let data_dir_path = PathBuf::from_str(env!("CARGO_MANIFEST_DIR"))
         .unwrap()

--- a/server/tests/reload_test.rs
+++ b/server/tests/reload_test.rs
@@ -53,7 +53,9 @@ use shiplift::builder::PullOptionsBuilder;
 //  - design a small dataset with an obvious journey that can be queried/modified
 
 #[test]
-fn main() {
+fn main() -> () {
+    let _log_guard = launch::logger::init_test_logger();
+
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -62,14 +64,14 @@ fn main() {
     runtime.block_on(run())
 }
 
-async fn run() {
-    let _log_guard = launch::logger::init_logger();
-
+async fn run() -> () {
     let start_test_datetime = Utc::now().naive_utc();
 
     let working_dir = tempdir::TempDir::new("loki_reload_data_test").unwrap();
     let working_dir_path = working_dir.path();
     // let working_dir_path = PathBuf::from_str("/tmp/test_loki/").unwrap();
+
+    println!("Coucou");
 
     let data_dir_path = PathBuf::from_str(env!("CARGO_MANIFEST_DIR"))
         .unwrap()
@@ -193,7 +195,9 @@ async fn start_rabbitmq_docker() -> String {
 
         while let Some(pull_result) = stream.next().await {
             match pull_result {
-                Ok(output) => info!("Pulled {:?} from docker hub.", output),
+                Ok(output) => {
+                    info!("Pulled {:?} from docker hub.", output)
+                }
                 Err(e) => {
                     panic!("Error while pulling from dockerhub: {}", e);
                 }

--- a/stop_areas/src/main.rs
+++ b/stop_areas/src/main.rs
@@ -35,7 +35,7 @@
 // www.navitia.io
 
 fn main() {
-    launch::logger::init_logger();
+    let _log_guard = launch::logger::init_logger();
     if let Err(err) = loki_stop_areas::run() {
         eprintln!("{:?}", err);
         std::process::exit(1);


### PR DESCRIPTION
- Avoid setting global logger (that panics when set multiple times, which seems to happen in test), use a log guard instead.
Cf https://docs.rs/tracing/latest/tracing/dispatcher/index.html
- Configure the test logger so that its output is correctly captured by the test framework.
Cf https://docs.rs/tracing-subscriber/0.3.3/tracing_subscriber/fmt/struct.Layer.html#method.with_test_writer

