### PR TITLE
Detect vehicles with no valid dates

### DIFF
--- a/launch/tests/utils/disruption_builder.rs
+++ b/launch/tests/utils/disruption_builder.rs
@@ -33,17 +33,17 @@ pub fn delete(vehicle_journey_id: String, date: NaiveDate) -> Disruption {
 }
 
 pub fn add(
-    vehicle_journey_id: String,
-    date: NaiveDate,
+    vehicle_journey_id: &str,
+    date: impl AsDate,
     stop_times_builder: StopTimesBuilder,
 ) -> Disruption {
     let trip = Trip {
-        vehicle_journey_id: vehicle_journey_id.clone(),
-        reference_date: date,
+        vehicle_journey_id: vehicle_journey_id.to_string(),
+        reference_date: date.as_date(),
     };
     let update = Update::Add(trip, stop_times_builder.stop_times);
     Disruption {
-        id: format!("Add {} {}", vehicle_journey_id, date),
+        id: format!("Add {} {}", vehicle_journey_id, date.as_date()),
         updates: vec![update],
     }
 }
@@ -67,7 +67,7 @@ pub fn modify(
 pub struct DisruptionBuilder {}
 
 pub struct StopTimesBuilder {
-    stop_times: Vec<StopTime>,
+    pub stop_times: Vec<StopTime>,
 }
 
 impl StopTimesBuilder {

--- a/src/models/base_model.rs
+++ b/src/models/base_model.rs
@@ -461,9 +461,19 @@ impl BaseModel {
         self.collections.stop_points.get_idx(stop_id)
     }
 
+    pub fn from_stop_name(&self, transfer_idx: BaseTransferIdx) -> &str {
+        self.collections.transfers[transfer_idx]
+            .from_stop_id
+            .as_str()
+    }
+
     pub fn to_stop(&self, transfer_idx: BaseTransferIdx) -> Option<BaseStopPointIdx> {
         let stop_id = self.collections.transfers[transfer_idx].to_stop_id.as_str();
         self.collections.stop_points.get_idx(stop_id)
+    }
+
+    pub fn to_stop_name(&self, transfer_idx: BaseTransferIdx) -> &str {
+        self.collections.transfers[transfer_idx].to_stop_id.as_str()
     }
 
     pub fn transfer_duration(&self, transfer_idx: BaseTransferIdx) -> PositiveDuration {

--- a/src/timetables.rs
+++ b/src/timetables.rs
@@ -231,6 +231,7 @@ pub enum InsertionError {
     BaseVehicleJourneyAlreadyExists(VehicleJourneyIdx),
     RealTimeVehicleJourneyAlreadyExistsOnDate(NaiveDate, VehicleJourneyIdx),
     InvalidDate(NaiveDate, VehicleJourneyIdx),
+    NoValidDates(VehicleJourneyIdx),
 }
 
 #[derive(Clone, Debug)]

--- a/src/timetables/periodic.rs
+++ b/src/timetables/periodic.rs
@@ -446,6 +446,9 @@ impl TimetablesTrait for PeriodicTimetables {
 
         for (_loads, dates) in load_patterns_dates.iter() {
             let days_pattern = days_patterns.get_from_dates(dates.iter(), calendar);
+            if days_patterns.is_empty_pattern(&days_pattern) {
+                continue;
+            }
 
             let inspect_result = generic_timetables::inspect(
                 flows.clone(),
@@ -462,6 +465,9 @@ impl TimetablesTrait for PeriodicTimetables {
 
         for (loads, dates) in load_patterns_dates.into_iter() {
             let days_pattern = days_patterns.get_from_dates(dates.iter(), calendar);
+            if days_patterns.is_empty_pattern(&days_pattern) {
+                continue;
+            }
 
             let (base_days_pattern, real_time_days_pattern) = match real_time_level {
                 RealTimeLevel::Base => (days_pattern, days_pattern),

--- a/src/timetables/periodic_split_vj_by_tz.rs
+++ b/src/timetables/periodic_split_vj_by_tz.rs
@@ -428,6 +428,10 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
                 let days_pattern =
                     days_patterns.get_intersection(all_days_pattern, *timezone_days_pattern);
 
+                if days_patterns.is_empty_pattern(&days_pattern) {
+                    continue;
+                }
+
                 let apply_offset = |time_in_timezoned_day: SecondsSinceTimezonedDayStart| -> SecondsSinceUTCDayStart {
                     time_in_timezoned_day.to_utc(offset)
                 };
@@ -458,6 +462,10 @@ impl TimetablesTrait for PeriodicSplitVjByTzTimetables {
             {
                 let days_pattern =
                     days_patterns.get_intersection(all_days_pattern, *timezone_days_pattern);
+
+                if days_patterns.is_empty_pattern(&days_pattern) {
+                    continue;
+                }
 
                 let (base_days_pattern, real_time_days_pattern) = match real_time_level {
                     RealTimeLevel::Base => (days_pattern, days_pattern),

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -416,6 +416,13 @@ pub fn handle_insertion_error(
                 real_time_level,
             );
         }
+        NoValidDates(vehicle_journey_idx) => {
+            let vehicle_journey_name = model.vehicle_journey_name(vehicle_journey_idx);
+            error!(
+                "Trying to insert the vehicle journey {} with no valid dates.",
+                vehicle_journey_name,
+            );
+        }
         RealTimeVehicleJourneyAlreadyExistsOnDate(date, vehicle_journey_idx) => {
             let vehicle_journey_name = model.vehicle_journey_name(vehicle_journey_idx);
             error!(
@@ -456,7 +463,7 @@ fn handle_vehicletimes_error(
 
     let days_strings: Vec<String> = dates
         .iter()
-        .map(|date| date.format("%H:%M:%S %d-%b-%y").to_string())
+        .map(|date| date.format("%Y-%m-%d").to_string())
         .collect();
 
     let date = dates.first().unwrap();

--- a/src/transit_data/data_update.rs
+++ b/src/transit_data/data_update.rs
@@ -282,6 +282,10 @@ where
             }
         }
 
+        if valid_dates.clone().next().is_none() {
+            return Err(InsertionError::NoValidDates(vehicle_journey_idx));
+        }
+
         let stops = self.create_stops(stop_points).into_iter();
         let days = self
             .days_patterns

--- a/src/transit_data/init.rs
+++ b/src/transit_data/init.rs
@@ -54,7 +54,7 @@ use crate::{
 use transit_model::objects::VehicleJourney;
 use typed_index_collection::Idx;
 
-use tracing::{debug, info, trace, warn};
+use tracing::{info, warn};
 
 use super::{handle_insertion_error, Transfer, TransferData, TransferDurations};
 

--- a/src/transit_data/init.rs
+++ b/src/transit_data/init.rs
@@ -113,12 +113,12 @@ where
         let from_base_idx = base_model.from_stop(transfer_idx).ok_or(())?;
         let from_idx = StopPointIdx::Base(from_base_idx);
         let from_stop = self.stop_point_idx_to_stop.get(&from_idx).ok_or(())?;
-        let from_stop = from_stop.clone();
+        let from_stop = *from_stop;
 
         let to_base_idx = base_model.to_stop(transfer_idx).ok_or(())?;
         let to_idx = StopPointIdx::Base(to_base_idx);
-        let to_stop = self.stop_point_idx_to_stop.get(&to_idx).ok_or(())?.clone();
-        let to_stop = to_stop.clone();
+        let to_stop = self.stop_point_idx_to_stop.get(&to_idx).ok_or(())?;
+        let to_stop = *to_stop;
 
         let duration = base_model.transfer_duration(transfer_idx);
         let walking_duration = base_model.transfer_walking_duration(transfer_idx);
@@ -146,8 +146,8 @@ where
             walking_duration,
         };
         let transfer_data = TransferData {
-            from_stop: from_stop,
-            to_stop: to_stop,
+            from_stop,
+            to_stop,
             durations: durations.clone(),
             transit_model_transfer_idx: transfer_idx,
         };

--- a/src/transit_data/init.rs
+++ b/src/transit_data/init.rs
@@ -37,8 +37,9 @@
 use crate::{
     loads_data::LoadsData,
     models::{
-        base_model::BaseModel, real_time_model::RealTimeModel, ModelRefs, StopPointIdx,
-        TransferIdx, VehicleJourneyIdx,
+        base_model::{BaseModel, BaseTransferIdx},
+        real_time_model::RealTimeModel,
+        ModelRefs, StopPointIdx, TransferIdx, VehicleJourneyIdx,
     },
     time::{days_patterns::DaysPatterns, Calendar},
     timetables::day_to_timetable::VehicleJourneyToTimetable,
@@ -53,7 +54,7 @@ use crate::{
 use transit_model::objects::VehicleJourney;
 use typed_index_collection::Idx;
 
-use tracing::{info, warn};
+use tracing::{debug, info, trace, warn};
 
 use super::{handle_insertion_error, Transfer, TransferData, TransferDurations};
 
@@ -93,79 +94,72 @@ where
         info!("Inserting transfers");
 
         for transfer_idx in base_model.transfers() {
-            let duration = base_model.transfer_duration(transfer_idx);
-            let walking_duration = base_model.transfer_walking_duration(transfer_idx);
-            let has_from_idx = base_model.from_stop(transfer_idx);
-            let has_to_idx = base_model.to_stop(transfer_idx);
-            match (has_from_idx, has_to_idx) {
-                (Some(from_stop_point_idx), Some(to_stop_point_idx)) => {
-                    let from_stop_point_idx = StopPointIdx::Base(from_stop_point_idx);
-                    let to_stop_point_idx = StopPointIdx::Base(to_stop_point_idx);
-                    let transfer_idx = TransferIdx::Base(transfer_idx);
-                    self.insert_transfer(
-                        from_stop_point_idx,
-                        to_stop_point_idx,
-                        transfer_idx,
-                        duration,
-                        walking_duration,
-                    )
-                }
-                _ => {
+            let _ = self.insert_base_transfer(transfer_idx, base_model)
+                .map_err(|()| {
                     warn!(
-                        "Skipping transfer {:?} because at least one of its stops is unknown.",
-                        transfer_idx
+                        "Skipping transfer between {} and {} because at least one of its stops is unknown. ",
+                        base_model.from_stop_name(transfer_idx),
+                        base_model.to_stop_name(transfer_idx),
                     );
-                }
-            }
+                });
         }
     }
 
-    fn insert_transfer(
+    fn insert_base_transfer(
         &mut self,
-        from_stop_point_idx: StopPointIdx,
-        to_stop_point_idx: StopPointIdx,
+        transfer_idx: BaseTransferIdx,
+        base_model: &BaseModel,
+    ) -> Result<(), ()> {
+        let from_base_idx = base_model.from_stop(transfer_idx).ok_or(())?;
+        let from_idx = StopPointIdx::Base(from_base_idx);
+        let from_stop = self.stop_point_idx_to_stop.get(&from_idx).ok_or(())?;
+        let from_stop = from_stop.clone();
+
+        let to_base_idx = base_model.to_stop(transfer_idx).ok_or(())?;
+        let to_idx = StopPointIdx::Base(to_base_idx);
+        let to_stop = self.stop_point_idx_to_stop.get(&to_idx).ok_or(())?.clone();
+        let to_stop = to_stop.clone();
+
+        let duration = base_model.transfer_duration(transfer_idx);
+        let walking_duration = base_model.transfer_walking_duration(transfer_idx);
+
+        let transfer_idx = TransferIdx::Base(transfer_idx);
+
+        self.insert_transfer_inner(from_stop, to_stop, transfer_idx, duration, walking_duration);
+
+        Ok(())
+    }
+
+    fn insert_transfer_inner(
+        &mut self,
+        from_stop: Stop,
+        to_stop: Stop,
         transfer_idx: TransferIdx,
         duration: PositiveDuration,
         walking_duration: PositiveDuration,
     ) {
-        let has_from_stop = self.stop_point_idx_to_stop.get(&from_stop_point_idx);
-        let has_to_stop = self.stop_point_idx_to_stop.get(&to_stop_point_idx);
-
-        match (has_from_stop, has_to_stop) {
-            (Some(from_stop), Some(to_stop)) => {
-                let transfer = Transfer {
-                    idx: self.transfers_data.len(),
-                };
-                let durations = TransferDurations {
-                    total_duration: duration,
-                    walking_duration,
-                };
-                let transfer_data = TransferData {
-                    from_stop: *from_stop,
-                    to_stop: *to_stop,
-                    durations: durations.clone(),
-                    transit_model_transfer_idx: transfer_idx,
-                };
-                self.transfers_data.push(transfer_data);
-                let from_stop_data = &mut self.stops_data[from_stop.idx];
-                from_stop_data.outgoing_transfers.push((
-                    *to_stop,
-                    durations.clone(),
-                    transfer.clone(),
-                ));
-                let to_stop_data = &mut self.stops_data[to_stop.idx];
-                to_stop_data
-                    .incoming_transfers
-                    .push((*from_stop, durations, transfer));
-            }
-            _ => {
-                warn!(
-                    "Transfer {:?} is between stops which does not appears in the data. \
-                    I ignore it.",
-                    transfer_idx
-                );
-            }
-        }
+        let transfer = Transfer {
+            idx: self.transfers_data.len(),
+        };
+        let durations = TransferDurations {
+            total_duration: duration,
+            walking_duration,
+        };
+        let transfer_data = TransferData {
+            from_stop: from_stop,
+            to_stop: to_stop,
+            durations: durations.clone(),
+            transit_model_transfer_idx: transfer_idx,
+        };
+        self.transfers_data.push(transfer_data);
+        let from_stop_data = &mut self.stops_data[from_stop.idx];
+        from_stop_data
+            .outgoing_transfers
+            .push((to_stop, durations.clone(), transfer.clone()));
+        let to_stop_data = &mut self.stops_data[to_stop.idx];
+        to_stop_data
+            .incoming_transfers
+            .push((from_stop, durations, transfer));
     }
 
     fn insert_base_vehicle_journey(
@@ -185,6 +179,12 @@ where
                     err
                 );
                 })?;
+        // let rt_model = RealTimeModel::new();
+        // let refs = ModelRefs::new(base_model, &rt_model);
+        // debug!("Trying to insert vj {} on stops : \n {:#?}",
+        //     base_model.vehicle_journey_name(vehicle_journey_idx),
+        //     stop_times.clone().map(|stop_time| refs.stop_point_uri(&stop_time.stop)).collect::<Vec<_>>()
+        // );
         if stop_times.len() < 2 {
             warn!(
                 "Skipping vehicle journey {} because it has less than 2 stop times.",


### PR DESCRIPTION
- Do not try to add vehicle with no valid dates into transit_data, returns an error when this happens.
- add tests where we try to insert various invalid vehicle into transit_data