### PR TITLE
Do not stop the compute worker when an error occurs in request handling

### DIFF
--- a/server/src/compute_worker.rs
+++ b/server/src/compute_worker.rs
@@ -98,7 +98,12 @@ impl ComputeWorker {
         (result, requests_channel_sender)
     }
 
-    pub fn run(mut self) -> Result<(), Error> {
+    pub fn run(mut self) {
+        let run_result = self.run_loop();
+        error!("Worker {} stopped : {:#?}", &self.worker_id.id, run_result);
+    }
+
+    pub fn run_loop(&mut self) -> Result<(), Error> {
         info!("Worker {} has launched.", self.worker_id.id);
         loop {
             // block on receiving message

--- a/server/src/load_balancer.rs
+++ b/server/src/load_balancer.rs
@@ -208,8 +208,8 @@ impl LoadBalancer {
             tokio::select! {
                 // this indicates to tokio to poll the futures in the order they appears below
                 // see https://docs.rs/tokio/1.12.0/tokio/macro.select.html#fairness
-                // here use this give priority to forwarding responses from workers to zmq
-                // receiving new requests from zmq has a lower priority
+                // here this give priority to forwarding responses from workers to zmq
+                // over receiving new requests from zmq
                 biased;
 
                 // receive responses from worker threads


### PR DESCRIPTION
log an error message instead, and keep working.