### PR TITLE
build: more extensible build configuration

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [build]
-rustflags = ["-C", "target-feature=+avx2,+fma"]
+rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "target-feature=+avx2,+fma"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [build]
-rustflags = "-C target-feature=+avx2,+fma"
+rustflags = ["-C", "target-feature=+avx2,+fma"]

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,10 +15,10 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - name: Install libzmq
+    - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install -y libzmq3-dev
+        sudo apt install -y libzmq3-dev lld
 
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,10 +15,10 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - name: Install libzmq
+    - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install -y libzmq3-dev
+        sudo apt install -y libzmq3-dev lld
 
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,9 +16,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
-      - name: Install libzmq
+      - name: Install dependencies
         run: |
-            sudo apt install libzmq3-dev
+            sudo apt install libzmq3-dev lld
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,9 +17,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'
-    - name: Install libzmq
+    - name: Install dependencies
       run: |
-        sudo apt install libzmq3-dev
+        sudo apt install libzmq3-dev lld
     - name: Install Rust stable
       uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -55,7 +55,7 @@ jobs:
     - name: install dependencies
       run: |
         sudo apt update
-        sudo apt install -y python3 python3-pip git
+        sudo apt install -y python3 python3-pip git lld
         pip install pre-commit
     - name: Pre-commit
       run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,8 +16,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'
-    - name: Install libzmq
-      run: sudo apt install libzmq3-dev
+    - name: Install dependencies
+      run: sudo apt install libzmq3-dev lld
     - name: Check compilation
       run: cargo check --workspace --verbose
 
@@ -37,8 +37,8 @@ jobs:
     - uses: Swatinem/rust-cache@v1
       with:
         key: ${{ matrix.build_type.name }}-${{ matrix.features }}
-    - name: Install libzmq
-      run: sudo apt install libzmq3-dev
+    - name: Install dependencies
+      run: sudo apt install libzmq3-dev lld
     - name: Build & Test
       run: cargo test --workspace ${{ matrix.build_type.flag }} ${{ matrix.features }}
 

--- a/Readme.rst
+++ b/Readme.rst
@@ -46,12 +46,16 @@ See the docker-readme_ for usage.
 Development
 =========
 
-To be able to compile this project, you'll need to have libraries for zmq and initialize the submodule that brings protobuf description for Navitia.
+To be able to compile this project, you'll need to:
+
+- initialize the submodule that brings protobuf description for Navitia
+- have libraries for zmq and PostgreSQL
+- have the `lld` linker (faster than the default `ld`) which is not installed on most default Linux distributions
 
 .. code-block::
 
     git submodule update --init --recursive
-    sudo apt install libzmq3-dev
+    sudo apt install libzmq3-dev libpq-dev lld
 
 Acknowledgments
 =========


### PR DESCRIPTION
With Cargo, you can have a repository configuration but also, a local machine configuration in `~/.cargo/config.toml`. However, Cargo needs to be able to reconcile both in the end. It happens that reconciling arrays is easier. I actually had the following in my local configuration.

```toml
[build]
rustflags = ["-C", "link-arg=-fuse-ld=lld"]
```

When I was trying to compile `loki`, the following error was happening.

<details>
<summary>Details</summary>
<pre>
error: could not load Cargo configuration

Caused by:
  failed to merge configuration at `/home/woshilapin/.cargo/config.toml`

Caused by:
  failed to merge key `build` between /home/woshilapin/projects/kisio/loki/.cargo/config and /home/woshilapin/.cargo/config.toml

Caused by:
  failed to merge key `rustflags` between /home/woshilapin/projects/kisio/loki/.cargo/config and /home/woshilapin/.cargo/config.toml

Caused by:
  failed to merge config value from `/home/woshilapin/.cargo/config.toml` into `/home/woshilapin/projects/kisio/loki/.cargo/config`: expected string, but found array
</pre>
</details>

With the current PR, this is no longer a problem.