### PR TITLE
Make chaos optionnal

### DIFF
--- a/server/config_files/data_in_local_folder.toml
+++ b/server/config_files/data_in_local_folder.toml
@@ -63,6 +63,18 @@ connect_retry_interval = '00:00:10'
 reload_request_time_to_live = '00:00:02'
 reload_kirin_timeout = '00:00:10'
 
+# Configures the connection to a chaos database that will be used
+# to retreive the history of chaos disruptions when the public transport data is (re)loaded
+# Optional.
+# If not present, the retreival of past chaos disruptions will be disabled
 [chaos]
+# connection string to the chaos database
+# for example : "postgres://guest:guest@localhost:5432/chaos"
 database = 'postgres://login:password@chaos_hostname:5432/chaos'
+
+# During reload of chaos disruption
+# we will ask the database to send
+# blocks of rows of size `batch_size`
+# Optional.
+# Defaults to 1_000_000
 batch_size = 1_000_000

--- a/server/config_files/data_in_local_folder.toml
+++ b/server/config_files/data_in_local_folder.toml
@@ -63,6 +63,6 @@ connect_retry_interval = '00:00:10'
 reload_request_time_to_live = '00:00:02'
 reload_kirin_timeout = '00:00:10'
 
-[chaos_params]
-chaos_database = 'postgres://login:password@chaos_hostname:5432/chaos'
-chaos_batch_size = 1000000
+[chaos]
+database = 'postgres://login:password@chaos_hostname:5432/chaos'
+batch_size = 1_000_000

--- a/server/config_files/data_in_s3.toml
+++ b/server/config_files/data_in_s3.toml
@@ -32,6 +32,18 @@ connect_retry_interval = '00:00:10'
 reload_request_time_to_live = '00:00:02'
 reload_kirin_timeout = '00:00:10'
 
+# Configures the connection to a chaos database that will be used
+# to retreive the history of chaos disruptions when the public transport data is (re)loaded
+# Optional.
+# If not present, the retreival of past chaos disruptions will be disabled
 [chaos]
+# connection string to the chaos database
+# for example : "postgres://guest:guest@localhost:5432/chaos"
 database = 'postgres://login:password@chaos_hostname:5432/chaos'
+
+# During reload of chaos disruption
+# we will ask the database to send
+# blocks of rows of size `batch_size`
+# Optional.
+# Defaults to 1_000_000
 batch_size = 1_000_000

--- a/server/config_files/data_in_s3.toml
+++ b/server/config_files/data_in_s3.toml
@@ -8,7 +8,7 @@ bucket_region = 'http://s3_hostname/'
 bucket_access_key = 'loki_rw'
 bucket_secret_key = 'my_secret_key'
 data_path_key = 'my_coverage/ntfs.zip'
-bucket_timeout_in_ms = 30000
+bucket_timeout_in_ms = 30_000
 
 
 [default_request_params]
@@ -32,6 +32,6 @@ connect_retry_interval = '00:00:10'
 reload_request_time_to_live = '00:00:02'
 reload_kirin_timeout = '00:00:10'
 
-[chaos_params]
-chaos_database = 'postgres://login:password@chaos_hostname:5432/chaos'
-chaos_batch_size = 1_000_000
+[chaos]
+database = 'postgres://login:password@chaos_hostname:5432/chaos'
+batch_size = 1_000_000

--- a/server/src/server_config.rs
+++ b/server/src/server_config.rs
@@ -73,7 +73,7 @@ pub struct ServerConfig {
     pub rabbitmq: RabbitMqParams,
 
     #[serde(default)]
-    pub chaos_params: ChaosParams,
+    pub chaos: Option<ChaosParams>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -96,7 +96,7 @@ impl ServerConfig {
             instance_name: instance_name.to_string(),
             default_request_params: config::RequestParams::default(),
             rabbitmq: RabbitMqParams::default(),
-            chaos_params: ChaosParams::default(),
+            chaos: None,
             nb_workers: default_nb_workers(),
         }
     }
@@ -184,27 +184,19 @@ impl Default for RabbitMqParams {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ChaosParams {
-    #[serde(default = "default_chaos_database")]
-    pub chaos_database: String,
-    #[serde(default = "default_batch_size")]
-    pub chaos_batch_size: u32,
-}
+    /// connection string to the chaos database
+    /// for example : "postgres://guest:guest@localhost:5432/chaos"
+    pub database: String,
 
-pub fn default_chaos_database() -> String {
-    "postgres://guest:guest@localhost:5432/chaos".to_string()
+    /// During reload of chaos disruption
+    /// we will ask the database to send
+    /// blocks of rows of size `batch_size`
+    #[serde(default = "default_batch_size")]
+    pub batch_size: u32,
 }
 
 pub fn default_batch_size() -> u32 {
-    5000
-}
-
-impl Default for ChaosParams {
-    fn default() -> Self {
-        Self {
-            chaos_database: default_chaos_database(),
-            chaos_batch_size: default_batch_size(),
-        }
-    }
+    1_000_000
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/server/src/server_config.rs
+++ b/server/src/server_config.rs
@@ -72,6 +72,10 @@ pub struct ServerConfig {
     #[serde(default)]
     pub rabbitmq: RabbitMqParams,
 
+    /// Configures the connection to a chaos database that will be used
+    /// to retreive the history of chaos disruptions when the public transport data is (re)loaded
+    /// If None, the retreival of past chaos disruptions will be disabled.
+    /// Defaults to None.
     #[serde(default)]
     pub chaos: Option<ChaosParams>,
 }


### PR DESCRIPTION
- do not provide a default chaos database configuration
- when chaos is not configured, warn with a log, and just skip the reload_chaos step.