### PR TITLE
Remove DataUpdate and DataIo traits

### DIFF
--- a/launch/src/read.rs
+++ b/launch/src/read.rs
@@ -40,7 +40,7 @@ use anyhow::{format_err, Error};
 use loki::{
     models::base_model::{self, BaseModel},
     tracing::{info, warn},
-    transit_model, DataIO, DataTrait, LoadsData, PositiveDuration,
+    transit_model, DataTrait, LoadsData, PositiveDuration,
 };
 use std::{path::PathBuf, str::FromStr, time::SystemTime};
 

--- a/launch/tests/update_data_test.rs
+++ b/launch/tests/update_data_test.rs
@@ -47,7 +47,7 @@ use loki::{
         VehicleJourneyIdx,
     },
     timetables::InsertionError,
-    DataTrait, DataUpdate, RealTimeLevel,
+    DataTrait, RealTimeLevel,
 };
 use utils::{
     disruption_builder::StopTimesBuilder,

--- a/server/src/master_worker.rs
+++ b/server/src/master_worker.rs
@@ -38,7 +38,7 @@ use anyhow::{bail, Context, Error};
 use launch::loki::{
     models::{base_model::BaseModel, real_time_model::RealTimeModel},
     tracing::{error, info},
-    DataIO, TransitData,
+    TransitData,
 };
 use std::sync::{Arc, RwLock};
 use tokio::{runtime::Builder, signal, sync::mpsc};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub use transit_model;
 pub use typed_index_collection;
 
 pub use transit_data::data_interface::{
-    Data as DataTrait, DataIO, DataUpdate, DataWithIters, RealTimeLevel, TransitTypes,
+    Data as DataTrait, DataWithIters, RealTimeLevel, TransitTypes,
 };
 
 pub use loads_data::LoadsData;

--- a/src/models/real_time_disruption/apply_disruption.rs
+++ b/src/models/real_time_disruption/apply_disruption.rs
@@ -43,16 +43,15 @@ use crate::{
         data_interface::Data as DataTrait, handle_insertion_error, handle_modify_error,
         handle_removal_error,
     },
+    TransitData,
 };
 
 use crate::models::{base_model::BaseModel, ModelRefs};
 
-use crate::DataUpdate;
-
-pub(super) fn delete_trip<Data: DataTrait + DataUpdate>(
+pub(super) fn delete_trip(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     vehicle_journey_idx: &VehicleJourneyIdx,
     date: NaiveDate,
 ) {
@@ -92,10 +91,10 @@ pub(super) fn delete_trip<Data: DataTrait + DataUpdate>(
     }
 }
 
-pub(super) fn add_trip<Data: DataTrait + DataUpdate>(
+pub(super) fn add_trip(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     vehicle_journey_idx: VehicleJourneyIdx,
     date: NaiveDate,
     stop_times: Vec<models::StopTime>,
@@ -140,10 +139,10 @@ pub(super) fn add_trip<Data: DataTrait + DataUpdate>(
     }
 }
 
-pub fn modify_trip<Data: DataTrait + DataUpdate>(
+pub fn modify_trip(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     vehicle_journey_idx: &VehicleJourneyIdx,
     date: &NaiveDate,
     stop_times: Vec<models::StopTime>,

--- a/src/models/real_time_disruption/chaos_disruption.rs
+++ b/src/models/real_time_disruption/chaos_disruption.rs
@@ -41,7 +41,7 @@ use crate::{
         RealTimeModel, StopPointIdx, VehicleJourneyIdx,
     },
     time::calendar,
-    transit_data::data_interface::{Data as DataTrait, DataUpdate},
+    TransitData,
 };
 
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
@@ -233,11 +233,11 @@ pub enum ChaosImpactError {
     DeletePresentTrip(VehicleJourneyId, NaiveDate),
 }
 
-pub fn store_and_apply_chaos_disruption<Data: DataTrait + DataUpdate>(
+pub fn store_and_apply_chaos_disruption(
     real_time_model: &mut RealTimeModel,
     disruption: ChaosDisruption,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
 ) {
     debug!("Apply chaos disruption {}", disruption.id);
     let disruption_idx = real_time_model.chaos_disruptions.len();
@@ -259,11 +259,11 @@ pub fn store_and_apply_chaos_disruption<Data: DataTrait + DataUpdate>(
     }
 }
 
-pub fn cancel_chaos_disruption<Data: DataTrait + DataUpdate>(
+pub fn cancel_chaos_disruption(
     real_time_model: &mut RealTimeModel,
     disruption_id: &str,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
 ) {
     debug!("Cancel chaos disruption {disruption_id}");
 
@@ -292,11 +292,11 @@ pub fn cancel_chaos_disruption<Data: DataTrait + DataUpdate>(
     }
 }
 
-fn apply_impact<Data: DataTrait + DataUpdate>(
+fn apply_impact(
     real_time_model: &mut RealTimeModel,
     impact: &ChaosImpact,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     impact_idx: &ChaosImpactIdx,
     cancel_impact: bool,
 ) {
@@ -471,10 +471,10 @@ fn apply_impact<Data: DataTrait + DataUpdate>(
     }
 }
 
-fn apply_on_base_vehicle_journey<Data: DataTrait + DataUpdate>(
+fn apply_on_base_vehicle_journey(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     vehicle_journey_id: &str,
     application_periods: &TimePeriods,
     chaos_impact_idx: &ChaosImpactIdx,
@@ -510,10 +510,10 @@ fn apply_on_base_vehicle_journey<Data: DataTrait + DataUpdate>(
     }
 }
 
-fn apply_on_base_vehicle_journey_idx<Data: DataTrait + DataUpdate>(
+fn apply_on_base_vehicle_journey_idx(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     base_vehicle_journey_idx: BaseVehicleJourneyIdx,
     application_periods: &TimePeriods,
     chaos_impact_idx: &ChaosImpactIdx,
@@ -538,10 +538,10 @@ fn apply_on_base_vehicle_journey_idx<Data: DataTrait + DataUpdate>(
     }
 }
 
-fn dispatch_on_base_vehicle_journey<Data: DataTrait + DataUpdate>(
+fn dispatch_on_base_vehicle_journey(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     base_vehicle_journey_idx: BaseVehicleJourneyIdx,
     date: NaiveDate,
     chaos_impact_idx: &ChaosImpactIdx,
@@ -630,10 +630,10 @@ fn dispatch_on_base_vehicle_journey<Data: DataTrait + DataUpdate>(
     }
 }
 
-fn apply_on_network<Data: DataTrait + DataUpdate>(
+fn apply_on_network(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     network_id: &str,
     application_periods: &TimePeriods,
     chaos_impact_idx: &ChaosImpactIdx,
@@ -673,10 +673,10 @@ fn apply_on_network<Data: DataTrait + DataUpdate>(
     Ok(())
 }
 
-fn apply_on_line<Data: DataTrait + DataUpdate>(
+fn apply_on_line(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     line_id: &str,
     application_periods: &TimePeriods,
     chaos_impact_idx: &ChaosImpactIdx,
@@ -715,10 +715,10 @@ fn apply_on_line<Data: DataTrait + DataUpdate>(
     Ok(())
 }
 
-fn apply_on_route<Data: DataTrait + DataUpdate>(
+fn apply_on_route(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     route_id: &str,
     application_periods: &TimePeriods,
     chaos_impact_idx: &ChaosImpactIdx,
@@ -757,10 +757,10 @@ fn apply_on_route<Data: DataTrait + DataUpdate>(
     Ok(())
 }
 
-fn apply_on_stop_area<Data: DataTrait + DataUpdate>(
+fn apply_on_stop_area(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     stop_area_id: &str,
     application_periods: &TimePeriods,
     chaos_impact_idx: &ChaosImpactIdx,
@@ -806,10 +806,10 @@ fn apply_on_stop_area<Data: DataTrait + DataUpdate>(
     Ok(())
 }
 
-fn apply_on_stop_point<Data: DataTrait + DataUpdate>(
+fn apply_on_stop_point(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     stop_point_id: &str,
     application_periods: &TimePeriods,
     chaos_impact_idx: &ChaosImpactIdx,
@@ -848,10 +848,10 @@ fn apply_on_stop_point<Data: DataTrait + DataUpdate>(
     Ok(())
 }
 
-fn apply_on_stop_point_by_closure<Data: DataTrait + DataUpdate, F: Fn(&StopPointIdx) -> bool>(
+fn apply_on_stop_point_by_closure<F: Fn(&StopPointIdx) -> bool>(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     is_stop_point_concerned: F,
     application_periods: &TimePeriods,
     chaos_impact_idx: &ChaosImpactIdx,
@@ -952,10 +952,10 @@ fn apply_on_stop_point_by_closure<Data: DataTrait + DataUpdate, F: Fn(&StopPoint
     }
 }
 
-fn remove_stop_points_from_trip<Data: DataTrait + DataUpdate, F: Fn(&StopPointIdx) -> bool>(
+fn remove_stop_points_from_trip<F: Fn(&StopPointIdx) -> bool>(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     is_stop_point_concerned: &F,
     application_periods: &TimePeriods,
     base_vehicle_journey_idx: BaseVehicleJourneyIdx,
@@ -1051,10 +1051,10 @@ fn remove_stop_points_from_trip<Data: DataTrait + DataUpdate, F: Fn(&StopPointId
     );
 }
 
-fn cancel_impact<Data: DataTrait + DataUpdate>(
+fn cancel_impact(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     chaos_impact_idx: &ChaosImpactIdx,
     chaos_object_idx: &ChaosImpactObjectIdx,
     base_vehicle_journey_idx: BaseVehicleJourneyIdx,

--- a/src/models/real_time_disruption/kirin_disruption.rs
+++ b/src/models/real_time_disruption/kirin_disruption.rs
@@ -40,7 +40,7 @@ use crate::{
         real_time_model::{KirinDisruptionIdx, TripVersion},
         VehicleJourneyIdx,
     },
-    transit_data::data_interface::{Data as DataTrait, DataUpdate},
+    TransitData,
 };
 
 use crate::{
@@ -101,11 +101,11 @@ pub enum KirinUpdateError {
     DeleteAbsentTrip(VehicleJourneyId, NaiveDate),
 }
 
-pub fn store_and_apply_kirin_disruption<Data: DataTrait + DataUpdate>(
+pub fn store_and_apply_kirin_disruption(
     real_time_model: &mut RealTimeModel,
     disruption: KirinDisruption,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
 ) {
     let kirin_disruption_idx = KirinDisruptionIdx {
         idx: real_time_model.kirin_disruptions.len(),
@@ -151,10 +151,10 @@ pub fn store_and_apply_kirin_disruption<Data: DataTrait + DataUpdate>(
     real_time_model.kirin_disruptions.push(disruption);
 }
 
-fn update_new_trip<Data: DataTrait + DataUpdate>(
+fn update_new_trip(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     vehicle_journey_id: &str,
     date: NaiveDate,
     update_data: &UpdateData,
@@ -211,10 +211,10 @@ fn update_new_trip<Data: DataTrait + DataUpdate>(
     Ok(())
 }
 
-fn update_base_trip<Data: DataTrait + DataUpdate>(
+fn update_base_trip(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     vehicle_journey_id: &str,
     date: NaiveDate,
     update_data: &UpdateData,
@@ -280,10 +280,10 @@ fn update_base_trip<Data: DataTrait + DataUpdate>(
     Ok(())
 }
 
-fn delete_trip<Data: DataTrait + DataUpdate>(
+fn delete_trip(
     real_time_model: &mut RealTimeModel,
     base_model: &BaseModel,
-    data: &mut Data,
+    data: &mut TransitData,
     vehicle_journey_id: &str,
     date: NaiveDate,
     kirin_disruption_idx: KirinDisruptionIdx,

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -42,9 +42,7 @@ use chrono::NaiveDate;
 
 use crate::{
     loads_data::Load,
-    models::{
-        base_model::BaseModel, ModelRefs, StopPointIdx, StopTimeIdx, TransferIdx, VehicleJourneyIdx,
-    },
+    models::{ModelRefs, StopPointIdx, StopTimeIdx, TransferIdx, VehicleJourneyIdx},
     time::{days_patterns::DaysPatterns, Calendar, PositiveDuration, SecondsSinceDatasetUTCStart},
     timetables::{
         day_to_timetable::VehicleJourneyToTimetable,
@@ -444,12 +442,6 @@ impl data_interface::Data for TransitData {
 
     fn mission_id(&self, mission: &Self::Mission) -> usize {
         self.timetables.mission_id(mission)
-    }
-}
-
-impl data_interface::DataIO for TransitData {
-    fn new(base_model: &BaseModel) -> Self {
-        Self::_new(base_model)
     }
 }
 

--- a/src/transit_data/data_init.rs
+++ b/src/transit_data/data_init.rs
@@ -167,7 +167,7 @@ impl VJGroupedByStayIn {
 }
 
 impl TransitData {
-    pub fn _new(base_model: &BaseModel) -> Self {
+    pub fn new(base_model: &BaseModel) -> Self {
         let nb_of_stop_points = base_model.nb_of_stop_points();
         let nb_transfers = base_model.nb_of_transfers();
 

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -1,8 +1,7 @@
 use crate::{
-    loads_data::{Load, LoadsData},
-    models::{base_model::BaseModel, StopPointIdx, StopTimeIdx, TransferIdx, VehicleJourneyIdx},
-    time::{PositiveDuration, SecondsSinceDatasetUTCStart, SecondsSinceTimezonedDayStart},
-    timetables::{FlowDirection, InsertionError, ModifyError, RemovalError},
+    loads_data::Load,
+    models::{StopPointIdx, StopTimeIdx, TransferIdx, VehicleJourneyIdx},
+    time::{PositiveDuration, SecondsSinceDatasetUTCStart},
 };
 use chrono::{NaiveDate, NaiveDateTime};
 pub use typed_index_collection::Idx;
@@ -195,54 +194,6 @@ pub trait Data: TransitTypes {
 pub enum RealTimeLevel {
     Base,
     RealTime,
-}
-
-pub trait DataUpdate {
-    fn remove_real_time_vehicle(
-        &mut self,
-        vehicle_journey_idx: &VehicleJourneyIdx,
-        date: NaiveDate,
-    ) -> Result<(), RemovalError>;
-
-    fn insert_real_time_vehicle<Stops, Flows, Dates, BoardTimes, DebarkTimes>(
-        &mut self,
-        stops: Stops,
-        flows: Flows,
-        board_times: BoardTimes,
-        debark_times: DebarkTimes,
-        loads_data: &LoadsData,
-        valid_dates: Dates,
-        timezone: chrono_tz::Tz,
-        vehicle_journey_idx: VehicleJourneyIdx,
-    ) -> Result<(), InsertionError>
-    where
-        Stops: Iterator<Item = StopPointIdx> + ExactSizeIterator + Clone,
-        Flows: Iterator<Item = FlowDirection> + ExactSizeIterator + Clone,
-        Dates: Iterator<Item = chrono::NaiveDate> + Clone,
-        BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
-        DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone;
-
-    fn modify_real_time_vehicle<Stops, Flows, Dates, BoardTimes, DebarkTimes>(
-        &mut self,
-        stops: Stops,
-        flows: Flows,
-        board_times: BoardTimes,
-        debark_times: DebarkTimes,
-        loads_data: &LoadsData,
-        valid_dates: Dates,
-        timezone: chrono_tz::Tz,
-        vehicle_journey_idx: &VehicleJourneyIdx,
-    ) -> Result<(), ModifyError>
-    where
-        Stops: Iterator<Item = StopPointIdx> + ExactSizeIterator + Clone,
-        Flows: Iterator<Item = FlowDirection> + ExactSizeIterator + Clone,
-        Dates: Iterator<Item = chrono::NaiveDate> + Clone,
-        BoardTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone,
-        DebarkTimes: Iterator<Item = SecondsSinceTimezonedDayStart> + ExactSizeIterator + Clone;
-}
-
-pub trait DataIO {
-    fn new(base_model: &BaseModel) -> Self;
 }
 
 pub trait DataIters<'a>: TransitTypes

--- a/src/transit_data/data_update.rs
+++ b/src/transit_data/data_update.rs
@@ -45,13 +45,10 @@ use crate::{
 
 use crate::{time::SecondsSinceTimezonedDayStart, timetables::FlowDirection};
 
-use super::{
-    data_interface::{self, RealTimeLevel},
-    Mission,
-};
+use super::{data_interface::RealTimeLevel, Mission};
 
-impl data_interface::DataUpdate for TransitData {
-    fn remove_real_time_vehicle(
+impl TransitData {
+    pub fn remove_real_time_vehicle(
         &mut self,
         vehicle_journey_idx: &VehicleJourneyIdx,
         date: chrono::NaiveDate,
@@ -94,7 +91,7 @@ impl data_interface::DataUpdate for TransitData {
         Ok(())
     }
 
-    fn insert_real_time_vehicle<Stops, Flows, Dates, BoardTimes, DebarkTimes>(
+    pub fn insert_real_time_vehicle<Stops, Flows, Dates, BoardTimes, DebarkTimes>(
         &mut self,
         stop_points: Stops,
         flows: Flows,
@@ -126,7 +123,7 @@ impl data_interface::DataUpdate for TransitData {
         )
     }
 
-    fn modify_real_time_vehicle<Stops, Flows, Dates, BoardTimes, DebarkTimes>(
+    pub fn modify_real_time_vehicle<Stops, Flows, Dates, BoardTimes, DebarkTimes>(
         &mut self,
         stops: Stops,
         flows: Flows,


### PR DESCRIPTION
These traits were only implemented for TransitData.
So now all disruption handling is done on TransitData, rather than on a generic Data : DataTrait+DataUpdate